### PR TITLE
Filter events

### DIFF
--- a/app/src/androidTest/java/com/github/se/gatherspot/screens/EventsScreen.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/screens/EventsScreen.kt
@@ -1,6 +1,7 @@
 package com.github.se.gatherspot.screens
 
 import androidx.compose.ui.test.SemanticsNodeInteractionsProvider
+import com.github.se.gatherspot.model.Interests
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import io.github.kakaocup.compose.node.element.KNode
 
@@ -13,6 +14,8 @@ class EventsScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val createMenu: KNode = onNode { hasTestTag("createMenu") }
   val emptyText: KNode = onNode { hasTestTag("empty") }
   val eventsList: KNode = onNode { hasTestTag("eventsList") }
-  val loadingText: KNode = onNode { hasTestTag("loading") }
-  val fetchedText: KNode = onNode { hasTestTag("fetched") }
+  val dropdown: KNode = onNode { hasTestTag("dropdown") }
+  val refresh: KNode = onNode { hasTestTag("refresh") }
+  val categories: List<KNode> =
+      enumValues<Interests>().toList().map { i -> onNode { hasTestTag(i.toString()) } }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -3,10 +3,14 @@ package com.github.se.gatherspot.ui
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.swipeUp
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.gatherspot.EventFirebaseConnection
 import com.github.se.gatherspot.model.EventsViewModel
+import com.github.se.gatherspot.model.Interests
 import com.github.se.gatherspot.screens.EventsScreen
 import com.github.se.gatherspot.ui.navigation.NavigationActions
 import io.github.kakaocup.compose.node.element.ComposeScreen
@@ -47,6 +51,12 @@ class EventsTest {
         assertExists()
         assertHasClickAction()
       }
+
+      refresh {
+        assertExists()
+        assertIsDisplayed()
+        assertHasClickAction()
+      }
     }
   }
 
@@ -70,6 +80,99 @@ class EventsTest {
         assertIsDisplayed()
         performGesture { swipeUp(400F, 0F, 1000) }
       }
+      EventFirebaseConnection.offset = null
+    }
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun testRefreshButtonFunctional() {
+    val viewModel = EventsViewModel()
+    Thread.sleep(5000)
+    assert(viewModel.getLoadedEvents().size.toLong() == EventsViewModel.PAGESIZE)
+    composeTestRule.setContent {
+      val nav = NavigationActions(rememberNavController())
+      Events(viewModel = viewModel, nav = nav)
+    }
+
+    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
+      refresh {
+        assertExists()
+        performClick()
+      }
+      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("fetch"), 500)
+      composeTestRule.waitUntilDoesNotExist(hasTestTag("fetch"), 10000)
+      assert(viewModel.getLoadedEvents().size.toLong() == 2 * EventsViewModel.PAGESIZE)
+      EventFirebaseConnection.offset = null
+    }
+  }
+
+  @OptIn(ExperimentalTestApi::class)
+  @Test
+  fun dropdownMenuFunctional() {
+    composeTestRule.setContent {
+      val viewModel = EventsViewModel()
+      val nav = NavigationActions(rememberNavController())
+      Events(viewModel = viewModel, nav = nav)
+    }
+
+    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
+      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 10000)
+      filterMenu {
+        assertIsDisplayed()
+        performClick()
+      }
+
+      dropdown { assertIsDisplayed() }
+
+      var c = 0
+      for (category in categories) {
+        category {
+          composeTestRule
+              .onNodeWithTag("dropdown")
+              .performScrollToNode(hasTestTag(enumValues<Interests>().toList()[c].toString()))
+          assertExists()
+          performClick()
+          performClick()
+          c++
+        }
+      }
+    }
+    EventFirebaseConnection.offset = null
+  }
+
+  @Test
+  fun filterWorks() {
+    val viewModel = EventsViewModel()
+    Thread.sleep(5000)
+    composeTestRule.setContent {
+      val nav = NavigationActions(rememberNavController())
+      Events(viewModel = viewModel, nav = nav)
+    }
+    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
+      filterMenu {
+        assertIsDisplayed()
+        performClick()
+      }
+
+      dropdown { assertIsDisplayed() }
+
+      val index = Interests.SPORT.ordinal
+
+      categories[index] {
+        composeTestRule
+            .onNodeWithTag("dropdown")
+            .performScrollToNode(hasTestTag(enumValues<Interests>().toList()[index].toString()))
+        assertExists()
+        performClick()
+      }
+
+      filterMenu { performClick() }
+
+      composeTestRule.waitForIdle()
+      assert(
+          viewModel.uiState.value.list.all { e -> e.categories?.contains(Interests.SPORT) ?: true })
+      EventFirebaseConnection.offset = null
     }
   }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.swipeUp
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.github.se.gatherspot.EventFirebaseConnection
 import com.github.se.gatherspot.model.EventsViewModel
 import com.github.se.gatherspot.model.Interests
 import com.github.se.gatherspot.screens.EventsScreen
@@ -80,7 +79,6 @@ class EventsTest {
         assertIsDisplayed()
         performGesture { swipeUp(400F, 0F, 1000) }
       }
-      EventFirebaseConnection.offset = null
     }
   }
 
@@ -89,7 +87,7 @@ class EventsTest {
   fun testRefreshButtonFunctional() {
     val viewModel = EventsViewModel()
     Thread.sleep(5000)
-    assert(viewModel.getLoadedEvents().size.toLong() == EventsViewModel.PAGESIZE)
+    assert(viewModel.getLoadedEvents().size.toLong() == viewModel.PAGESIZE)
     composeTestRule.setContent {
       val nav = NavigationActions(rememberNavController())
       Events(viewModel = viewModel, nav = nav)
@@ -102,8 +100,7 @@ class EventsTest {
       }
       composeTestRule.waitUntilAtLeastOneExists(hasTestTag("fetch"), 500)
       composeTestRule.waitUntilDoesNotExist(hasTestTag("fetch"), 10000)
-      assert(viewModel.getLoadedEvents().size.toLong() == 2 * EventsViewModel.PAGESIZE)
-      EventFirebaseConnection.offset = null
+      assert(viewModel.getLoadedEvents().size.toLong() == 2 * viewModel.PAGESIZE)
     }
   }
 
@@ -138,7 +135,6 @@ class EventsTest {
         }
       }
     }
-    EventFirebaseConnection.offset = null
   }
 
   @Test
@@ -172,7 +168,6 @@ class EventsTest {
       composeTestRule.waitForIdle()
       assert(
           viewModel.uiState.value.list.all { e -> e.categories?.contains(Interests.SPORT) ?: true })
-      EventFirebaseConnection.offset = null
     }
   }
 }

--- a/app/src/main/java/com/github/se/gatherspot/model/EventsViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/EventsViewModel.kt
@@ -13,18 +13,45 @@ class EventsViewModel : ViewModel() {
   val PAGESIZE: Long = 9
   private var _uiState = MutableStateFlow(UIState())
   val uiState: StateFlow<UIState> = _uiState
+  var loadedEvents: MutableList<Event> = mutableListOf()
 
   init {
     viewModelScope.launch {
       val events = EventFirebaseConnection.fetchNextEvents(PAGESIZE)
       _uiState.value = UIState(events)
+      loadedEvents = events.toMutableList()
     }
   }
 
   suspend fun fetchNext() {
+    removeFilter()
     val nextEvents = EventFirebaseConnection.fetchNextEvents(PAGESIZE)
-    val newEvents = _uiState.value.list.apply { addAll(nextEvents) }
+    loadedEvents.addAll(nextEvents)
+    _uiState.value = UIState(loadedEvents)
+  }
+
+  fun filter(s: List<Interests>) {
+    if (s.isEmpty()) {
+      removeFilter()
+      return
+    }
+    val newEvents =
+        loadedEvents.filter { event -> event.categories?.any { it in s } ?: false }.toMutableList()
     _uiState.value = UIState(newEvents)
+  }
+
+  private fun filterInterests() {
+    // TO BE CHANGED WHEN ProfileFirebaseConnection DONE
+    val userInterests = listOf(Interests.BASKETBALL, Interests.CHESS)
+    val newEvents =
+        _uiState.value.list
+            .filter { event -> event.categories?.any { it in userInterests } ?: false }
+            .toMutableList()
+    _uiState.value = UIState(newEvents)
+  }
+
+  fun removeFilter() {
+    _uiState.value = UIState(loadedEvents)
   }
 }
 

--- a/app/src/main/java/com/github/se/gatherspot/model/EventsViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/EventsViewModel.kt
@@ -9,11 +9,13 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class EventsViewModel : ViewModel() {
+  companion object {
+    val PAGESIZE: Long = 9
+  }
 
-  val PAGESIZE: Long = 9
   private var _uiState = MutableStateFlow(UIState())
   val uiState: StateFlow<UIState> = _uiState
-  var loadedEvents: MutableList<Event> = mutableListOf()
+  private var loadedEvents: MutableList<Event> = mutableListOf()
 
   init {
     viewModelScope.launch {
@@ -52,6 +54,10 @@ class EventsViewModel : ViewModel() {
 
   fun removeFilter() {
     _uiState.value = UIState(loadedEvents)
+  }
+
+  fun getLoadedEvents(): MutableList<Event> {
+    return loadedEvents
   }
 }
 

--- a/app/src/main/java/com/github/se/gatherspot/model/EventsViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/EventsViewModel.kt
@@ -9,17 +9,16 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
 class EventsViewModel : ViewModel() {
-  companion object {
-    val PAGESIZE: Long = 9
-  }
 
+  val PAGESIZE: Long = 9
   private var _uiState = MutableStateFlow(UIState())
   val uiState: StateFlow<UIState> = _uiState
   private var loadedEvents: MutableList<Event> = mutableListOf()
+  val eventFirebaseConnection = EventFirebaseConnection()
 
   init {
     viewModelScope.launch {
-      val events = EventFirebaseConnection.fetchNextEvents(PAGESIZE)
+      val events = eventFirebaseConnection.fetchNextEvents(PAGESIZE)
       _uiState.value = UIState(events)
       loadedEvents = events.toMutableList()
     }
@@ -27,7 +26,7 @@ class EventsViewModel : ViewModel() {
 
   suspend fun fetchNext() {
     removeFilter()
-    val nextEvents = EventFirebaseConnection.fetchNextEvents(PAGESIZE)
+    val nextEvents = eventFirebaseConnection.fetchNextEvents(PAGESIZE)
     loadedEvents.addAll(nextEvents)
     _uiState.value = UIState(loadedEvents)
   }

--- a/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
@@ -178,8 +178,7 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
             LaunchedEffect(lazyState.isScrollInProgress) {
               loading = false
               fetched = false
-              val isAtBottom =
-                  (lazyState.firstVisibleItemIndex + EventsViewModel.PAGESIZE) >= events.size
+              val isAtBottom = (lazyState.firstVisibleItemIndex + viewModel.PAGESIZE) >= events.size
               val currentScrollPosition = lazyState.firstVisibleItemScrollOffset
               val downwards =
                   currentScrollPosition >= previousScrollPosition && currentScrollPosition > 0

--- a/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
@@ -1,11 +1,15 @@
 package com.github.se.gatherspot.ui
 
+import android.content.ContentValues.TAG
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -15,8 +19,13 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Done
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Divider
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -41,6 +50,7 @@ import androidx.compose.ui.unit.sp
 import com.github.se.gatherspot.EventFirebaseConnection
 import com.github.se.gatherspot.R
 import com.github.se.gatherspot.model.EventsViewModel
+import com.github.se.gatherspot.model.Interests
 import com.github.se.gatherspot.model.event.Event
 import com.github.se.gatherspot.model.event.EventStatus
 import com.github.se.gatherspot.ui.navigation.BottomNavigationMenu
@@ -51,12 +61,19 @@ import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.delay
 
 /** Composable that displays events * */
+
+// listOf("Your interests", "None")
 @Composable
 fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
+
   val state = viewModel.uiState.collectAsState()
   var previousScrollPosition by remember { mutableIntStateOf(0) }
   var loading by remember { mutableStateOf(false) }
   var fetched by remember { mutableStateOf(false) }
+  var showDropdownMenu by remember { mutableStateOf(false) }
+  val filters = enumValues<Interests>().toList()
+  var interestsSelected = mutableListOf<Interests>()
+  var fetch by remember { mutableStateOf(false) }
 
   Scaffold(
       modifier = Modifier.testTag("EventsScreen"),
@@ -69,11 +86,42 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
                 Text(
                     text = "Filter events", fontSize = 18.sp, modifier = Modifier.testTag("filter"))
                 Spacer(modifier = Modifier.width(10.dp))
-                Icon(
-                    imageVector = Icons.Filled.Menu,
-                    contentDescription = null,
-                    modifier = Modifier.clickable {}.testTag("filterMenu"))
-                Spacer(modifier = Modifier.width(80.dp))
+                Box {
+                  Icon(
+                      imageVector = Icons.Filled.Menu,
+                      contentDescription = null,
+                      modifier =
+                          Modifier.clickable { showDropdownMenu = !showDropdownMenu }
+                              .testTag("filterMenu"))
+                  DropdownMenu(
+                      modifier = Modifier.height(300.dp),
+                      expanded = showDropdownMenu,
+                      onDismissRequest = {
+                        showDropdownMenu = false
+                        viewModel.filter(interestsSelected)
+                        interestsSelected = mutableListOf()
+                      }) {
+                        DropdownMenuItem(
+                            text = { Text("REMOVE FILTER") },
+                            onClick = {
+                              viewModel.removeFilter()
+                              showDropdownMenu = false
+                            },
+                            leadingIcon = { Icon(Icons.Filled.Clear, "clear") })
+
+                        filters.forEach { s -> StatefulDropdownItem(s, interestsSelected) }
+                      }
+                }
+                Spacer(modifier = Modifier.width(30.dp))
+                Icon(Icons.Filled.Refresh, "fetch", modifier = Modifier.clickable { fetch = true })
+                LaunchedEffect(fetch) {
+                  if (fetch) {
+                    Log.d(TAG, "entered")
+                    viewModel.fetchNext()
+                    fetch = false
+                  }
+                }
+                Spacer(modifier = Modifier.width(30.dp))
                 Text(
                     text = "Create an event",
                     fontSize = 18.sp,
@@ -103,8 +151,9 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
       }) { paddingValues ->
         val events = state.value.list
         val lazyState = rememberLazyListState()
+        Log.d(TAG, "size = " + events.size.toString())
         when {
-          events.isEmpty() -> Empty()
+          events.isEmpty() -> Empty(viewModel)
           else -> {
             LazyColumn(
                 state = lazyState,
@@ -130,13 +179,6 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
           }
         }
       }
-}
-
-@Composable
-fun Empty() {
-  Row(modifier = Modifier.padding(vertical = 40.dp).testTag("empty")) {
-    Text(text = "Loading...", color = Color.Black)
-  }
 }
 
 @Composable
@@ -187,4 +229,39 @@ fun EventRow(event: Event, navigation: NavigationActions) {
         }
       }
   Divider(color = Color.Black, thickness = 1.dp)
+}
+
+@Composable
+fun Empty(viewModel: EventsViewModel) {
+  Box(modifier = Modifier.fillMaxSize().testTag("empty"), contentAlignment = Alignment.Center) {
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+      Text("No events matched your query")
+      Text(
+          "Remove filter",
+          color = Color.Blue,
+          modifier = Modifier.clickable { viewModel.removeFilter() })
+    }
+  }
+}
+
+@Composable
+fun StatefulDropdownItem(interest: Interests, interestsSelected: MutableList<Interests>) {
+  var selected by remember { mutableStateOf(false) }
+
+  DropdownMenuItem(
+      text = { Text(interest.toString()) },
+      onClick = {
+        selected = !selected
+        if (selected) {
+          interestsSelected.add(interest)
+        } else {
+          interestsSelected.remove(interest)
+        }
+      },
+      leadingIcon = {
+        if (selected) {
+          Icon(Icons.Filled.Done, "")
+        }
+      },
+  )
 }

--- a/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
@@ -91,10 +91,16 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
                       imageVector = Icons.Filled.Menu,
                       contentDescription = null,
                       modifier =
-                          Modifier.clickable { showDropdownMenu = !showDropdownMenu }
+                          Modifier.clickable {
+                                showDropdownMenu = !showDropdownMenu
+                                if (!showDropdownMenu) {
+                                  viewModel.filter(interestsSelected)
+                                  interestsSelected = mutableListOf()
+                                }
+                              }
                               .testTag("filterMenu"))
                   DropdownMenu(
-                      modifier = Modifier.height(300.dp),
+                      modifier = Modifier.height(300.dp).testTag("dropdown"),
                       expanded = showDropdownMenu,
                       onDismissRequest = {
                         showDropdownMenu = false
@@ -113,7 +119,10 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
                       }
                 }
                 Spacer(modifier = Modifier.width(30.dp))
-                Icon(Icons.Filled.Refresh, "fetch", modifier = Modifier.clickable { fetch = true })
+                Icon(
+                    Icons.Filled.Refresh,
+                    "fetch",
+                    modifier = Modifier.clickable { fetch = true }.testTag("refresh"))
                 LaunchedEffect(fetch) {
                   if (fetch) {
                     Log.d(TAG, "entered")
@@ -121,6 +130,7 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
                     fetch = false
                   }
                 }
+
                 Spacer(modifier = Modifier.width(30.dp))
                 Text(
                     text = "Create an event",
@@ -149,6 +159,11 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
             tabList = TOP_LEVEL_DESTINATIONS,
             selectedItem = nav.controller.currentBackStackEntry?.destination?.route)
       }) { paddingValues ->
+        if (fetch) {
+          Text(
+              modifier = Modifier.testTag("fetch").padding(vertical = 30.dp),
+              text = "Fetching new events...")
+        }
         val events = state.value.list
         val lazyState = rememberLazyListState()
         Log.d(TAG, "size = " + events.size.toString())
@@ -164,7 +179,8 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
             LaunchedEffect(lazyState.isScrollInProgress) {
               loading = false
               fetched = false
-              val isAtBottom = (lazyState.firstVisibleItemIndex + viewModel.PAGESIZE) >= events.size
+              val isAtBottom =
+                  (lazyState.firstVisibleItemIndex + EventsViewModel.PAGESIZE) >= events.size
               val currentScrollPosition = lazyState.firstVisibleItemScrollOffset
               val downwards =
                   currentScrollPosition >= previousScrollPosition && currentScrollPosition > 0
@@ -249,6 +265,7 @@ fun StatefulDropdownItem(interest: Interests, interestsSelected: MutableList<Int
   var selected by remember { mutableStateOf(false) }
 
   DropdownMenuItem(
+      modifier = Modifier.testTag(interest.toString()),
       text = { Text(interest.toString()) },
       onClick = {
         selected = !selected


### PR DESCRIPTION
I have added some features available on the main screen of events. More precisely, the user is now able to load new events by clicking on the refresh button (I'm just calling a function of EventsViewModel() I implemented). They can also decide to filter events based on their interests. I wrote UI/instrumented tests along with these features.