### PR TITLE
Update build.gradle.kts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    id ("com.android.application")
+    id("com.android.application")
+    id("com.google.gms.google-services")
     id ("org.jetbrains.kotlin.android")
     id("com.ncorti.ktfmt.gradle") version "0.16.0"
-    id("com.google.gms.google-services")
     id("jacoco")
     id("org.sonarqube") version "4.4.1.3373"
     id ("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
@@ -99,46 +99,99 @@ android {
 }
 
 dependencies {
-    implementation ("com.google.code.gson:gson:2.8.9")
+
+    // ---------------------- </IMPLEMENTATION ------------------
+    //</ Android COMPOSE
     implementation("androidx.compose.runtime:runtime-livedata")
-    implementation("com.google.code.gson:gson:2.10.1")
-    implementation("io.coil-kt:coil-compose:2.6.0")
-    implementation("androidx.core:core-ktx:1.7.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
     implementation("androidx.activity:activity-compose:1.8.2")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui:1.4.0")
     implementation("androidx.compose.ui:ui-tooling-preview:1.4.0")
-    implementation("androidx.compose.material3:material3:1.1.2")
+    implementation("androidx.compose.material:material")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material:1.6.2") //necessary for EventUI Automirrored to work
+    implementation(platform("androidx.compose:compose-bom:2023.08.00"))
+    ///>
+
+    //</firebase
+    implementation(platform("com.google.firebase:firebase-bom:32.8.1")) //changed to newer version
+    implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-database")
+    implementation("com.google.firebase:firebase-firestore")
+    implementation("com.google.firebase:firebase-auth")
+    implementation("com.firebaseui:firebase-ui-auth:7.2.0") // Can't find it anywhere
+    ///>
+
+    //</Used for uploading images
+    implementation ("com.google.firebase:firebase-storage")
+    implementation("androidx.fragment:fragment:1.5.5")
+    implementation("com.squareup.okhttp3:okhttp:3.10.0")
+    ///>
+
+
+    //<gson
+    implementation("com.google.code.gson:gson:2.10.1")
+    implementation("com.google.code.gson:gson:2.8.6") //DOUBLON
+    ///>
+
+    //</Android navigation
     implementation("androidx.navigation:navigation-compose:2.6.0-rc01")
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.5")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.5")
-    implementation("androidx.fragment:fragment:1.5.5")
-    implementation("androidx.compose.material:material:1.6.2")
-    implementation(platform("androidx.compose:compose-bom:2023.08.00"))
 
+    ///>
+
+    //</Google Maps
     implementation("com.google.maps.android:maps-compose:4.3.0")
     implementation("com.google.maps.android:maps-compose-utils:4.3.0")
+    ///>
 
+    //</gms play
     implementation("com.google.android.gms:play-services-auth:20.6.0")
     implementation("com.google.android.gms:play-services-maps:18.1.0")
-    implementation("com.google.android.material:material:1.10.0")
-    implementation("com.google.android.play:core-ktx:1.7.0")
-    implementation("com.google.code.gson:gson:2.8.6")
+    ///>
 
-    implementation("com.google.firebase:firebase-auth-ktx:22.3.0")
-    implementation("com.google.firebase:firebase-database-ktx:20.3.0")
-    implementation("com.google.firebase:firebase-firestore:24.10.0")
-    implementation("com.firebaseui:firebase-ui-auth:7.2.0")
-    implementation(platform("com.google.firebase:firebase-bom:32.7.2"))
+    //</coil
+    implementation("io.coil-kt:coil-compose:2.6.0")
+    ///>
+
+
+    implementation("androidx.appcompat:appcompat:1.6.1")
+
+
+
+
+
+
+
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 
-    //implementation("androidx.navigation:navigation-compose:2.6.0-rc01")
+
     implementation("com.squareup.okhttp3:okhttp:3.10.0")
-    implementation("com.squareup.okhttp3:okhttp:4.9.0") //For location
+    implementation("com.squareup.okhttp3:okhttp:4.9.0") //For location //DOUBLON
+
+
+    implementation("androidx.core:core-ktx:1.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
+    implementation("com.google.android.play:core-ktx:1.7.0")
+
+
+
+
+    implementation("com.google.android.material:material:1.10.0") //Different than compose:material ?
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+
+    implementation("androidx.compose.ui:ui-graphics")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
+
+
+
+
+
+    // ---------------------- /IMPLEMENTATION> ------------------
+
 
     // DEBUG IMPLEMENTATION DEPENDENCIES
 
@@ -171,49 +224,14 @@ dependencies {
     androidTestImplementation("com.kaspersky.android-components:kaspresso-compose-support:1.4.1")
 
 
-    // Dependencies for using MockK in instrumented tests
+    //</ Dependencies for using MockK in instrumented tests
     androidTestImplementation("io.mockk:mockk:1.13.7")
     androidTestImplementation("io.mockk:mockk-android:1.13.7")
     androidTestImplementation("io.mockk:mockk-agent:1.13.7")
     androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
+    ///>
 
 
-    implementation("androidx.core:core-ktx:1.7.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
-    implementation("androidx.activity:activity-compose:1.8.2")
-    implementation("androidx.compose.ui:ui:1.4.0")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.4.0")
-    implementation("androidx.compose.material:material:1.1.1")
-    implementation("androidx.compose.material3:material3:1.1.2")
-    implementation("androidx.navigation:navigation-compose:2.6.0-rc01")
-    implementation("com.google.maps.android:maps-compose:4.3.0")
-    implementation("com.google.maps.android:maps-compose-utils:4.3.0")
-    implementation("com.google.firebase:firebase-database-ktx:20.3.0")
-    implementation("com.google.firebase:firebase-firestore:24.10.0")
-    implementation("com.google.android.play:core-ktx:1.7.0")
-    implementation("com.google.android.gms:play-services-maps:18.1.0")
-    implementation("com.google.android.material:material:1.10.0")
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.7.5")
-    implementation("androidx.navigation:navigation-ui-ktx:2.7.5")
-    implementation(platform("androidx.compose:compose-bom:2023.08.00"))
-    implementation("androidx.compose.ui:ui-graphics")
-    implementation("com.google.android.gms:play-services-auth:20.6.0")
-    implementation("com.google.firebase:firebase-auth-ktx:22.3.0")
-    implementation("com.google.firebase:firebase-database-ktx:20.3.0")
-    implementation(platform("com.google.firebase:firebase-bom:32.7.4"))
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
-    //Used for uploading images
-    implementation ("com.google.firebase:firebase-storage:20.0.0")
-    implementation("androidx.fragment:fragment:1.5.5")
-    implementation("com.squareup.okhttp3:okhttp:3.10.0")
-
-
-    testImplementation("org.mockito:mockito-core:3.11.2")
-    testImplementation("org.mockito:mockito-inline:2.13.0")
-    testImplementation ("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
-    testImplementation("junit:junit:4.13.2")
 
     androidTestImplementation("org.mockito:mockito-core:3.11.2")
     androidTestImplementation("org.mockito:mockito-inline:2.13.0")
@@ -227,8 +245,8 @@ dependencies {
     androidTestImplementation("com.kaspersky.android-components:kaspresso-allure-support:1.4.3")
     // Jetpack Compose support
     androidTestImplementation("com.kaspersky.android-components:kaspresso-compose-support:1.4.1")
-    androidTestImplementation("com.google.firebase:firebase-database-ktx:20.3.0")
-    androidTestImplementation("com.google.firebase:firebase-firestore:24.10.0")
+    androidTestImplementation("com.google.firebase:firebase-database")
+    androidTestImplementation("com.google.firebase:firebase-firestore")
 }
 tasks.withType<Test> {
     // Configure Jacoco for each tests


### PR DESCRIPTION
Clean build.gradle.kts according to these reasonings :
1. the ktx packages are now available in the corresponding principal packages and the ktx are becoming deprecated.
2. if a bom is provided (for example in the case of compose), the version should be omitted by (material3:1.1.2 -> material3). The Bom already sets a version for these imports such that they are all compatible with one another. In addition when it comes to firebase functionality older versions might not work with our current firebase iteration
3. Regroup imports by theme. If something stops working it will be easier to manage