### PR TITLE
111 save draft event

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -185,9 +185,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
-
-
-
+    implementation(libs.androidx.core.animation)
 
 
     // ---------------------- /IMPLEMENTATION> ------------------

--- a/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
@@ -28,46 +28,39 @@ class LocalStorageTest {
             "attendanceMinCapacity",
             "inscriptionLimitDate",
             "inscriptionLimitTime",
-            setOf(
-                Interests.SPORT,
-                Interests.FOOTBALL,
-                Interests.BASKETBALL,
-                Interests.TENNIS),
+            setOf(Interests.SPORT, Interests.FOOTBALL, Interests.BASKETBALL, Interests.TENNIS),
             null)
 
-      localStorage.storeDraftEvent(draftEvent)
-      val loadedDraftEvent = localStorage.loadDraftEvent()
-      assert(loadedDraftEvent == draftEvent)
-      localStorage.deleteDraftEvent()
+    localStorage.storeDraftEvent(draftEvent)
+    val loadedDraftEvent = localStorage.loadDraftEvent()
+    assert(loadedDraftEvent == draftEvent)
+    localStorage.deleteDraftEvent()
   }
 
-    @Test fun deleteDraftEventTest() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val localStorage = LocalStorage(context)
-        val draftEvent =
-            DraftEvent(
-                "organiserId",
-                "title",
-                "description",
-                null,
-                "eventStartDate",
-                "eventEndDate",
-                "timeBeginning",
-                "timeEnding",
-                "attendanceMaxCapacity",
-                "attendanceMinCapacity",
-                "inscriptionLimitDate",
-                "inscriptionLimitTime",
-                emptySet(),
-                null)
+  @Test
+  fun deleteDraftEventTest() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val localStorage = LocalStorage(context)
+    val draftEvent =
+        DraftEvent(
+            "organiserId",
+            "title",
+            "description",
+            null,
+            "eventStartDate",
+            "eventEndDate",
+            "timeBeginning",
+            "timeEnding",
+            "attendanceMaxCapacity",
+            "attendanceMinCapacity",
+            "inscriptionLimitDate",
+            "inscriptionLimitTime",
+            emptySet(),
+            null)
 
-        localStorage.storeDraftEvent(draftEvent)
-        localStorage.deleteDraftEvent()
-        val loadedDraftEvent = localStorage.loadDraftEvent()
-        assert(loadedDraftEvent == null)
-    }
-
-
-
-
+    localStorage.storeDraftEvent(draftEvent)
+    localStorage.deleteDraftEvent()
+    val loadedDraftEvent = localStorage.loadDraftEvent()
+    assert(loadedDraftEvent == null)
+  }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
@@ -42,7 +42,6 @@ class LocalStorageTest {
     val localStorage = LocalStorage(context)
     val draftEvent =
         DraftEvent(
-            "organiserId",
             "title",
             "description",
             null,

--- a/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
@@ -1,0 +1,73 @@
+package com.github.se.gatherspot.cache
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.github.se.gatherspot.model.Interests
+import com.github.se.gatherspot.model.event.DraftEvent
+import com.github.se.gatherspot.model.location.Location
+import org.junit.Test
+
+class LocalStorageTest {
+  @Test fun loadDraftEventTest() {}
+
+  @Test
+  fun storeDraftEventTest() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val localStorage = LocalStorage(context)
+    val draftEvent =
+        DraftEvent(
+            "organiserId",
+            "title",
+            "description",
+            Location(0.0, 0.0, "Malibu"),
+            "eventStartDate",
+            "eventEndDate",
+            "timeBeginning",
+            "timeEnding",
+            "attendanceMaxCapacity",
+            "attendanceMinCapacity",
+            "inscriptionLimitDate",
+            "inscriptionLimitTime",
+            setOf(
+                Interests.SPORT,
+                Interests.FOOTBALL,
+                Interests.BASKETBALL,
+                Interests.TENNIS),
+            null)
+
+      localStorage.storeDraftEvent(draftEvent)
+      val loadedDraftEvent = localStorage.loadDraftEvent()
+      assert(loadedDraftEvent == draftEvent)
+      localStorage.deleteDraftEvent()
+  }
+
+    @Test fun deleteDraftEventTest() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val localStorage = LocalStorage(context)
+        val draftEvent =
+            DraftEvent(
+                "organiserId",
+                "title",
+                "description",
+                null,
+                "eventStartDate",
+                "eventEndDate",
+                "timeBeginning",
+                "timeEnding",
+                "attendanceMaxCapacity",
+                "attendanceMinCapacity",
+                "inscriptionLimitDate",
+                "inscriptionLimitTime",
+                emptySet(),
+                null)
+
+        localStorage.storeDraftEvent(draftEvent)
+        localStorage.deleteDraftEvent()
+        val loadedDraftEvent = localStorage.loadDraftEvent()
+        assert(loadedDraftEvent == null)
+    }
+
+
+
+
+}

--- a/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
@@ -61,5 +61,4 @@ class LocalStorageTest {
     val loadedDraftEvent = localStorage.loadDraftEvent()
     assert(loadedDraftEvent == null)
   }
-
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
@@ -62,32 +62,31 @@ class LocalStorageTest {
     assert(loadedDraftEvent == null)
   }
 
-    @Test
-    fun deleteDraftEventThrowException() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val localStorage = LocalStorage(context)
-        val draftEvent =
-            DraftEvent(
-                "title",
-                "description",
-                null,
-                "eventStartDate",
-                "eventEndDate",
-                "timeBeginning",
-                "timeEnding",
-                "attendanceMaxCapacity",
-                "attendanceMinCapacity",
-                "inscriptionLimitDate",
-                "inscriptionLimitTime",
-                emptySet(),
-                null)
-        localStorage.storeDraftEvent(draftEvent)
-        localStorage.deleteDraftEvent()
-        try {
-            localStorage.deleteDraftEvent()
-        } catch (e: Exception) {
-            assert(true)
-        }
+  @Test
+  fun deleteDraftEventThrowException() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val localStorage = LocalStorage(context)
+    val draftEvent =
+        DraftEvent(
+            "title",
+            "description",
+            null,
+            "eventStartDate",
+            "eventEndDate",
+            "timeBeginning",
+            "timeEnding",
+            "attendanceMaxCapacity",
+            "attendanceMinCapacity",
+            "inscriptionLimitDate",
+            "inscriptionLimitTime",
+            emptySet(),
+            null)
+    localStorage.storeDraftEvent(draftEvent)
+    localStorage.deleteDraftEvent()
+    try {
+      localStorage.deleteDraftEvent()
+    } catch (e: Exception) {
+      assert(true)
     }
-
+  }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
@@ -16,7 +16,6 @@ class LocalStorageTest {
     val localStorage = LocalStorage(context)
     val draftEvent =
         DraftEvent(
-            "organiserId",
             "title",
             "description",
             Location(0.0, 0.0, "Malibu"),

--- a/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
@@ -61,4 +61,33 @@ class LocalStorageTest {
     val loadedDraftEvent = localStorage.loadDraftEvent()
     assert(loadedDraftEvent == null)
   }
+
+    @Test
+    fun deleteDraftEventThrowException() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val localStorage = LocalStorage(context)
+        val draftEvent =
+            DraftEvent(
+                "title",
+                "description",
+                null,
+                "eventStartDate",
+                "eventEndDate",
+                "timeBeginning",
+                "timeEnding",
+                "attendanceMaxCapacity",
+                "attendanceMinCapacity",
+                "inscriptionLimitDate",
+                "inscriptionLimitTime",
+                emptySet(),
+                null)
+        localStorage.storeDraftEvent(draftEvent)
+        localStorage.deleteDraftEvent()
+        try {
+            localStorage.deleteDraftEvent()
+        } catch (e: Exception) {
+            assert(true)
+        }
+    }
+
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/cache/LocalStorageTest.kt
@@ -61,4 +61,5 @@ class LocalStorageTest {
     val loadedDraftEvent = localStorage.loadDraftEvent()
     assert(loadedDraftEvent == null)
   }
+
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/model/EventUtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/model/EventUtilsTest.kt
@@ -508,8 +508,7 @@ class EventUtilsTest {
         "inscriptionLimitTime",
         setOf(Interests.SPORT, Interests.FOOTBALL, Interests.BASKETBALL, Interests.TENNIS),
         null,
-        context
-    )
+        context)
     val draftEvent = eventUtils.retrieveFromDraft(context)
     Assert.assertEquals("title", draftEvent?.title)
     Assert.assertEquals("description", draftEvent?.description)
@@ -527,5 +526,32 @@ class EventUtilsTest {
     Assert.assertEquals(
         setOf(Interests.SPORT, Interests.FOOTBALL, Interests.BASKETBALL, Interests.TENNIS),
         draftEvent?.categories)
+    Assert.assertNull(draftEvent?.image)
+    eventUtils.deleteDraft(context)
+  }
+
+  @Test
+  fun deleteDraftEventTest() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    val eventUtils = EventUtils()
+    eventUtils.saveDraftEvent(
+        "title",
+        "description",
+        Location(0.0, 0.0, "Malibu"),
+        "eventStartDate",
+        "eventEndDate",
+        "timeBeginning",
+        "timeEnding",
+        "attendanceMaxCapacity",
+        "attendanceMinCapacity",
+        "inscriptionLimitDate",
+        "inscriptionLimitTime",
+        setOf(Interests.SPORT, Interests.FOOTBALL, Interests.BASKETBALL, Interests.TENNIS),
+        null,
+        context)
+    eventUtils.retrieveFromDraft(context)!!
+    eventUtils.deleteDraft(context)
+    val draftEvent = eventUtils.retrieveFromDraft(context)
+    Assert.assertNull(draftEvent)
   }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/model/EventUtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/model/EventUtilsTest.kt
@@ -507,7 +507,9 @@ class EventUtilsTest {
         "inscriptionLimitDate",
         "inscriptionLimitTime",
         setOf(Interests.SPORT, Interests.FOOTBALL, Interests.BASKETBALL, Interests.TENNIS),
-        context)
+        null,
+        context
+    )
     val draftEvent = eventUtils.retrieveFromDraft(context)
     Assert.assertEquals("title", draftEvent?.title)
     Assert.assertEquals("description", draftEvent?.description)

--- a/app/src/androidTest/java/com/github/se/gatherspot/model/EventUtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/model/EventUtilsTest.kt
@@ -1,3 +1,5 @@
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import com.github.se.gatherspot.firebase.EventFirebaseConnection
 import com.github.se.gatherspot.model.EventUtils
 import com.github.se.gatherspot.model.Interests
@@ -486,5 +488,42 @@ class EventUtilsTest {
     eventUtils.deleteEvent(event)
     val eventFromDBAfterDelete = runBlocking { EventFirebaseConnection.fetch("myEventToDelete") }
     Assert.assertNull(eventFromDBAfterDelete)
+  }
+
+  @Test
+  fun testSaveDraftEvent() {
+    val eventUtils = EventUtils()
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    eventUtils.saveDraftEvent(
+        "title",
+        "description",
+        Location(0.0, 0.0, "Malibu"),
+        "eventStartDate",
+        "eventEndDate",
+        "timeBeginning",
+        "timeEnding",
+        "attendanceMaxCapacity",
+        "attendanceMinCapacity",
+        "inscriptionLimitDate",
+        "inscriptionLimitTime",
+        setOf(Interests.SPORT, Interests.FOOTBALL, Interests.BASKETBALL, Interests.TENNIS),
+        context)
+    val draftEvent = eventUtils.retrieveFromDraft(context)
+    Assert.assertEquals("title", draftEvent?.title)
+    Assert.assertEquals("description", draftEvent?.description)
+    Assert.assertEquals(0.0, draftEvent?.location?.latitude)
+    Assert.assertEquals(0.0, draftEvent?.location?.longitude)
+    Assert.assertEquals("Malibu", draftEvent?.location?.name)
+    Assert.assertEquals("eventStartDate", draftEvent?.eventStartDate)
+    Assert.assertEquals("eventEndDate", draftEvent?.eventEndDate)
+    Assert.assertEquals("timeBeginning", draftEvent?.timeBeginning)
+    Assert.assertEquals("timeEnding", draftEvent?.timeEnding)
+    Assert.assertEquals("attendanceMaxCapacity", draftEvent?.attendanceMaxCapacity)
+    Assert.assertEquals("attendanceMinCapacity", draftEvent?.attendanceMinCapacity)
+    Assert.assertEquals("inscriptionLimitDate", draftEvent?.inscriptionLimitDate)
+    Assert.assertEquals("inscriptionLimitTime", draftEvent?.inscriptionLimitTime)
+    Assert.assertEquals(
+        setOf(Interests.SPORT, Interests.FOOTBALL, Interests.BASKETBALL, Interests.TENNIS),
+        draftEvent?.categories)
   }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/screens/EventDataFormScreen.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/screens/EventDataFormScreen.kt
@@ -13,6 +13,7 @@ class EventDataFormScreen(semanticsProvider: SemanticsNodeInteractionsProvider) 
   val eventScaffold: KNode = onNode { hasTestTag("EventDataFormScreen") }
   val topBar: KNode = onNode { hasTestTag("createEventTitle") }
   val backButton: KNode = onNode { hasTestTag("goBackButton") }
+  val clearButton: KNode = onNode { hasTestTag("clearFieldsButton") }
   val formColumn: KNode = onNode { hasTestTag("formColumn") }
 
   val eventTitle: KNode = onNode { hasTestTag("inputTitle") }

--- a/app/src/androidTest/java/com/github/se/gatherspot/screens/EventDataFormScreen.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/screens/EventDataFormScreen.kt
@@ -14,6 +14,7 @@ class EventDataFormScreen(semanticsProvider: SemanticsNodeInteractionsProvider) 
   val topBar: KNode = onNode { hasTestTag("createEventTitle") }
   val backButton: KNode = onNode { hasTestTag("goBackButton") }
   val clearButton: KNode = onNode { hasTestTag("clearFieldsButton") }
+  val saveDraftButton: KNode = onNode { hasTestTag("saveDraftButton") }
   val formColumn: KNode = onNode { hasTestTag("formColumn") }
 
   val eventTitle: KNode = onNode { hasTestTag("inputTitle") }

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/CreateEventTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/CreateEventTest.kt
@@ -560,17 +560,17 @@ class CreateEventTest {
     }
 
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
-        // Check if the draft event is displayed
-        eventTitle.assert(hasText("title"))
-        eventDescription.assert(hasText("description"))
-        eventStartDate.assert(hasText("12/04/2026"))
-        eventEndDate.assert(hasText("12/05/2026"))
-        eventTimeStart.assert(hasText("10:00"))
-        eventTimeEnd.assert(hasText("12:00"))
-        eventMaxAttendees.assert(hasText("100"))
-        eventMinAttendees.assert(hasText("10"))
-        eventInscriptionLimitDate.assert(hasText("10/04/2025"))
-        eventInscriptionLimitTime.assert(hasText("09:00"))
+      // Check if the draft event is displayed
+      eventTitle.assert(hasText("title"))
+      eventDescription.assert(hasText("description"))
+      eventStartDate.assert(hasText("12/04/2026"))
+      eventEndDate.assert(hasText("12/05/2026"))
+      eventTimeStart.assert(hasText("10:00"))
+      eventTimeEnd.assert(hasText("12:00"))
+      eventMaxAttendees.assert(hasText("100"))
+      eventMinAttendees.assert(hasText("10"))
+      eventInscriptionLimitDate.assert(hasText("10/04/2025"))
+      eventInscriptionLimitTime.assert(hasText("09:00"))
     }
     EventUtils().deleteDraft(context)
   }

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/CreateEventTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/CreateEventTest.kt
@@ -574,4 +574,44 @@ class CreateEventTest {
     }
     EventUtils().deleteDraft(context)
   }
+
+  @Test
+  fun testClickOnSaveDraft() {
+    val context = ApplicationProvider.getApplicationContext<Context>()
+    composeTestRule.setContent {
+      val navController = rememberNavController()
+      val eventUtils = EventUtils()
+      CreateEvent(nav = NavigationActions(navController), eventUtils)
+    }
+    ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
+      eventTitle.performTextInput("Test Event")
+      eventDescription.performTextInput("This is a test event")
+      eventStartDate.performTextInput("12/04/2026")
+      eventEndDate.performTextInput("12/05/2026")
+      eventTimeStart.performTextInput("10:00")
+      eventTimeEnd.performTextInput("12:00")
+      eventMaxAttendees.performTextInput("100")
+      eventMinAttendees.performTextInput("10")
+      eventInscriptionLimitDate.performTextInput("10/04/2025")
+      eventInscriptionLimitTime.performTextInput("09:00")
+
+      saveDraftButton {
+        assertExists()
+        performClick()
+      }
+      // Check if the draft event is displayed
+      eventTitle.assert(hasText("Test Event"))
+      eventDescription.assert(hasText("This is a test event"))
+      eventStartDate.assert(hasText("12/04/2026"))
+      eventEndDate.assert(hasText("12/05/2026"))
+      eventTimeStart.assert(hasText("10:00"))
+      eventTimeEnd.assert(hasText("12:00"))
+      eventMaxAttendees.assert(hasText("100"))
+      eventMinAttendees.assert(hasText("10"))
+      eventInscriptionLimitDate.assert(hasText("10/04/2025"))
+      eventInscriptionLimitTime.assert(hasText("09:00"))
+    }
+    EventUtils().retrieveFromDraft(context)!!
+    EventUtils().deleteDraft(context)
+  }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/utils/JsonCustomsSerializerTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/utils/JsonCustomsSerializerTest.kt
@@ -1,5 +1,8 @@
 package com.github.se.gatherspot.utils
 
+import android.util.Log
+import androidx.compose.ui.graphics.ImageBitmap
+import com.github.se.gatherspot.model.utils.ImageBitmapSerializer
 import com.github.se.gatherspot.model.utils.LocalDateDeserializer
 import com.github.se.gatherspot.model.utils.LocalDateSerializer
 import com.github.se.gatherspot.model.utils.LocalDateTimeDeserializer
@@ -42,5 +45,17 @@ class JsonCustomsSerializerTest {
         val deserializer = LocalDateTimeDeserializer()
         val localDateTime = deserializer.deserialize(jsonElement, LocalDateTime::class.java, null)
         assertEquals(LocalDateTime.of(2022, 12, 31, 23, 59), localDateTime)
+    }
+
+    @Test
+    fun testImageBitmapSerializer() {
+        val imageBitmap = ImageBitmap(30, 30)
+        val serializer = ImageBitmapSerializer()
+        val jsonElement = serializer.serialize(imageBitmap, ImageBitmap::class.java, null)
+        Log.d("ImageBitmapSerializer", jsonElement.toString())
+        val deserializer = ImageBitmapSerializer()
+        val deserializedImageBitmap = deserializer.deserialize(jsonElement, ImageBitmap::class.java, null)
+        assertEquals(imageBitmap.height, deserializedImageBitmap!!.height)
+        assertEquals(imageBitmap.width, deserializedImageBitmap.width)
     }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/utils/JsonCustomsSerializerTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/utils/JsonCustomsSerializerTest.kt
@@ -1,0 +1,46 @@
+package com.github.se.gatherspot.utils
+
+import com.github.se.gatherspot.model.utils.LocalDateDeserializer
+import com.github.se.gatherspot.model.utils.LocalDateSerializer
+import com.github.se.gatherspot.model.utils.LocalDateTimeDeserializer
+import com.github.se.gatherspot.model.utils.LocalDateTimeSerializer
+import com.google.gson.JsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class JsonCustomsSerializerTest {
+
+    @Test
+    fun testLocalDateSerializer() {
+        val localDate = LocalDate.of(2022, 12, 31)
+        val serializer = LocalDateSerializer()
+        val jsonElement = serializer.serialize(localDate, localDate::class.java, null)
+        assertEquals(JsonPrimitive("2022-12-31"), jsonElement)
+    }
+
+    @Test
+    fun testLocalDateDeserializer() {
+        val jsonElement = JsonPrimitive("2022-12-31")
+        val deserializer = LocalDateDeserializer()
+        val localDate = deserializer.deserialize(jsonElement, LocalDate::class.java, null)
+        assertEquals(LocalDate.of(2022, 12, 31), localDate)
+    }
+
+    @Test
+    fun testLocalDateTimeSerializer() {
+        val localDateTime = LocalDateTime.of(2022, 12, 31, 23, 59)
+        val serializer = LocalDateTimeSerializer()
+        val jsonElement = serializer.serialize(localDateTime, localDateTime::class.java, null)
+        assertEquals(JsonPrimitive("2022-12-31T23:59:00"), jsonElement)
+    }
+
+    @Test
+    fun testLocalDateTimeDeserializer(){
+        val jsonElement = JsonPrimitive("2022-12-31T23:59:00")
+        val deserializer = LocalDateTimeDeserializer()
+        val localDateTime = deserializer.deserialize(jsonElement, LocalDateTime::class.java, null)
+        assertEquals(LocalDateTime.of(2022, 12, 31, 23, 59), localDateTime)
+    }
+}

--- a/app/src/androidTest/java/com/github/se/gatherspot/utils/JsonCustomsSerializerTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/utils/JsonCustomsSerializerTest.kt
@@ -8,54 +8,55 @@ import com.github.se.gatherspot.model.utils.LocalDateSerializer
 import com.github.se.gatherspot.model.utils.LocalDateTimeDeserializer
 import com.github.se.gatherspot.model.utils.LocalDateTimeSerializer
 import com.google.gson.JsonPrimitive
-import org.junit.Assert.assertEquals
-import org.junit.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
 class JsonCustomsSerializerTest {
 
-    @Test
-    fun testLocalDateSerializer() {
-        val localDate = LocalDate.of(2022, 12, 31)
-        val serializer = LocalDateSerializer()
-        val jsonElement = serializer.serialize(localDate, localDate::class.java, null)
-        assertEquals(JsonPrimitive("2022-12-31"), jsonElement)
-    }
+  @Test
+  fun testLocalDateSerializer() {
+    val localDate = LocalDate.of(2022, 12, 31)
+    val serializer = LocalDateSerializer()
+    val jsonElement = serializer.serialize(localDate, localDate::class.java, null)
+    assertEquals(JsonPrimitive("2022-12-31"), jsonElement)
+  }
 
-    @Test
-    fun testLocalDateDeserializer() {
-        val jsonElement = JsonPrimitive("2022-12-31")
-        val deserializer = LocalDateDeserializer()
-        val localDate = deserializer.deserialize(jsonElement, LocalDate::class.java, null)
-        assertEquals(LocalDate.of(2022, 12, 31), localDate)
-    }
+  @Test
+  fun testLocalDateDeserializer() {
+    val jsonElement = JsonPrimitive("2022-12-31")
+    val deserializer = LocalDateDeserializer()
+    val localDate = deserializer.deserialize(jsonElement, LocalDate::class.java, null)
+    assertEquals(LocalDate.of(2022, 12, 31), localDate)
+  }
 
-    @Test
-    fun testLocalDateTimeSerializer() {
-        val localDateTime = LocalDateTime.of(2022, 12, 31, 23, 59)
-        val serializer = LocalDateTimeSerializer()
-        val jsonElement = serializer.serialize(localDateTime, localDateTime::class.java, null)
-        assertEquals(JsonPrimitive("2022-12-31T23:59:00"), jsonElement)
-    }
+  @Test
+  fun testLocalDateTimeSerializer() {
+    val localDateTime = LocalDateTime.of(2022, 12, 31, 23, 59)
+    val serializer = LocalDateTimeSerializer()
+    val jsonElement = serializer.serialize(localDateTime, localDateTime::class.java, null)
+    assertEquals(JsonPrimitive("2022-12-31T23:59:00"), jsonElement)
+  }
 
-    @Test
-    fun testLocalDateTimeDeserializer(){
-        val jsonElement = JsonPrimitive("2022-12-31T23:59:00")
-        val deserializer = LocalDateTimeDeserializer()
-        val localDateTime = deserializer.deserialize(jsonElement, LocalDateTime::class.java, null)
-        assertEquals(LocalDateTime.of(2022, 12, 31, 23, 59), localDateTime)
-    }
+  @Test
+  fun testLocalDateTimeDeserializer() {
+    val jsonElement = JsonPrimitive("2022-12-31T23:59:00")
+    val deserializer = LocalDateTimeDeserializer()
+    val localDateTime = deserializer.deserialize(jsonElement, LocalDateTime::class.java, null)
+    assertEquals(LocalDateTime.of(2022, 12, 31, 23, 59), localDateTime)
+  }
 
-    @Test
-    fun testImageBitmapSerializer() {
-        val imageBitmap = ImageBitmap(30, 30)
-        val serializer = ImageBitmapSerializer()
-        val jsonElement = serializer.serialize(imageBitmap, ImageBitmap::class.java, null)
-        Log.d("ImageBitmapSerializer", jsonElement.toString())
-        val deserializer = ImageBitmapSerializer()
-        val deserializedImageBitmap = deserializer.deserialize(jsonElement, ImageBitmap::class.java, null)
-        assertEquals(imageBitmap.height, deserializedImageBitmap!!.height)
-        assertEquals(imageBitmap.width, deserializedImageBitmap.width)
-    }
+  @Test
+  fun testImageBitmapSerializer() {
+    val imageBitmap = ImageBitmap(30, 30)
+    val serializer = ImageBitmapSerializer()
+    val jsonElement = serializer.serialize(imageBitmap, ImageBitmap::class.java, null)
+    Log.d("ImageBitmapSerializer", jsonElement.toString())
+    val deserializer = ImageBitmapSerializer()
+    val deserializedImageBitmap =
+        deserializer.deserialize(jsonElement, ImageBitmap::class.java, null)
+    assertEquals(imageBitmap.height, deserializedImageBitmap!!.height)
+    assertEquals(imageBitmap.width, deserializedImageBitmap.width)
+  }
 }

--- a/app/src/main/java/com/github/se/gatherspot/cache/LocalStorage.kt
+++ b/app/src/main/java/com/github/se/gatherspot/cache/LocalStorage.kt
@@ -1,0 +1,39 @@
+package com.github.se.gatherspot.cache
+
+import android.content.Context
+import com.github.se.gatherspot.model.event.DraftEvent
+import com.google.gson.Gson
+import java.io.InputStreamReader
+
+class LocalStorage(private val context: Context) {
+  private val gson = Gson()
+
+  fun loadDraftEvent(): DraftEvent? {
+    return try {
+      val inputStreamReader = InputStreamReader(context.openFileInput("draftEvent.json"))
+      val draftEventJson = inputStreamReader.readText()
+      gson.fromJson(draftEventJson, DraftEvent::class.java)
+    } catch (e: Exception) {
+      null
+    }
+  }
+
+  fun storeDraftEvent(draftEvent: DraftEvent) {
+    try {
+      val draftEventJson = gson.toJson(draftEvent)
+      context.openFileOutput("draftEvent.json", Context.MODE_PRIVATE).use {
+        it.write(draftEventJson.toByteArray())
+      }
+    } catch (e: Exception) {
+      throw Exception("Error storing draft event to local storage")
+    }
+  }
+
+  fun deleteDraftEvent() {
+    try {
+      context.deleteFile("draftEvent.json")
+    } catch (e: Exception) {
+      throw Exception("Error deleting draft event from local storage")
+    }
+  }
+}

--- a/app/src/main/java/com/github/se/gatherspot/cache/LocalStorage.kt
+++ b/app/src/main/java/com/github/se/gatherspot/cache/LocalStorage.kt
@@ -8,9 +8,8 @@ import com.google.gson.GsonBuilder
 import java.io.InputStreamReader
 
 class LocalStorage(private val context: Context) {
-  private val gson = GsonBuilder()
-    .registerTypeAdapter(Bitmap::class.java, ImageBitmapSerializer())
-    .create()
+  private val gson =
+      GsonBuilder().registerTypeAdapter(Bitmap::class.java, ImageBitmapSerializer()).create()
 
   fun loadDraftEvent(): DraftEvent? {
     return try {

--- a/app/src/main/java/com/github/se/gatherspot/cache/LocalStorage.kt
+++ b/app/src/main/java/com/github/se/gatherspot/cache/LocalStorage.kt
@@ -1,12 +1,16 @@
 package com.github.se.gatherspot.cache
 
 import android.content.Context
+import android.graphics.Bitmap
 import com.github.se.gatherspot.model.event.DraftEvent
-import com.google.gson.Gson
+import com.github.se.gatherspot.model.utils.ImageBitmapSerializer
+import com.google.gson.GsonBuilder
 import java.io.InputStreamReader
 
 class LocalStorage(private val context: Context) {
-  private val gson = Gson()
+  private val gson = GsonBuilder()
+    .registerTypeAdapter(Bitmap::class.java, ImageBitmapSerializer())
+    .create()
 
   fun loadDraftEvent(): DraftEvent? {
     return try {

--- a/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
@@ -1,8 +1,12 @@
 package com.github.se.gatherspot.model
 
+import android.content.Context
+import android.util.Log
+import com.github.se.gatherspot.cache.LocalStorage
 import com.github.se.gatherspot.firebase.EventFirebaseConnection
 import com.github.se.gatherspot.firebase.FirebaseCollection
 import com.github.se.gatherspot.firebase.IdListFirebaseConnection
+import com.github.se.gatherspot.model.event.DraftEvent
 import com.github.se.gatherspot.model.event.Event
 import com.github.se.gatherspot.model.event.EventStatus
 import com.github.se.gatherspot.model.location.Location
@@ -345,4 +349,52 @@ class EventUtils {
         }
         return@withContext suggestions
       }
+
+  fun saveDraftEvent(
+      title: String?,
+      description: String?,
+      location: Location?,
+      startDate: String?,
+      endDate: String?,
+      startTime: String?,
+      endTime: String?,
+      maxAttendees: String?,
+      minAttendees: String?,
+      dateLimitInscription: String?,
+      timeLimitInscription: String?,
+      categories: Set<Interests>?,
+      context: Context
+  ) {
+    val draftEvent =
+        DraftEvent(
+            title,
+            description,
+            location,
+            startDate,
+            endDate,
+            startTime,
+            endTime,
+            maxAttendees,
+            minAttendees,
+            dateLimitInscription,
+            timeLimitInscription,
+            categories = categories)
+
+    val localStorage = LocalStorage(context)
+    localStorage.storeDraftEvent(draftEvent)
+  }
+
+  fun retrieveFromDraft(context: Context): DraftEvent? {
+    val localStorage = LocalStorage(context)
+    return localStorage.loadDraftEvent()
+  }
+
+  fun deleteDraft(context: Context) {
+    val localStorage = LocalStorage(context)
+    try {
+      localStorage.deleteDraftEvent()
+    } catch (e: Exception) {
+      Log.e("EventUtils", "Error deleting draft event from local storage", e)
+    }
+  }
 }

--- a/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
@@ -2,6 +2,7 @@ package com.github.se.gatherspot.model
 
 import android.content.Context
 import android.util.Log
+import androidx.compose.ui.graphics.ImageBitmap
 import com.github.se.gatherspot.cache.LocalStorage
 import com.github.se.gatherspot.firebase.EventFirebaseConnection
 import com.github.se.gatherspot.firebase.FirebaseCollection
@@ -363,6 +364,7 @@ class EventUtils {
       dateLimitInscription: String?,
       timeLimitInscription: String?,
       categories: Set<Interests>?,
+      image : ImageBitmap?,
       context: Context
   ) {
     val draftEvent =
@@ -378,6 +380,7 @@ class EventUtils {
             minAttendees,
             dateLimitInscription,
             timeLimitInscription,
+            image = image,
             categories = categories)
 
     val localStorage = LocalStorage(context)

--- a/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
@@ -364,7 +364,7 @@ class EventUtils {
       dateLimitInscription: String?,
       timeLimitInscription: String?,
       categories: Set<Interests>?,
-      image : ImageBitmap?,
+      image: ImageBitmap?,
       context: Context
   ) {
     val draftEvent =

--- a/app/src/main/java/com/github/se/gatherspot/model/event/DraftEvent.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/event/DraftEvent.kt
@@ -22,5 +22,5 @@ data class DraftEvent(
     val inscriptionLimitDate: String?,
     val inscriptionLimitTime: String?,
     val categories: Set<Interests>? = emptySet(),
-    val images: ImageBitmap? = ImageBitmap(30, 30, config = ImageBitmapConfig.Rgb565)
+    val image: ImageBitmap? = ImageBitmap(30, 30, config = ImageBitmapConfig.Rgb565)
 )

--- a/app/src/main/java/com/github/se/gatherspot/model/event/DraftEvent.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/event/DraftEvent.kt
@@ -10,7 +10,6 @@ import com.github.se.gatherspot.model.location.Location
  * is saved as a string.
  */
 data class DraftEvent(
-    val organiserId: String,
     val title: String?,
     val description: String?,
     val location: Location?,

--- a/app/src/main/java/com/github/se/gatherspot/model/event/DraftEvent.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/event/DraftEvent.kt
@@ -1,0 +1,27 @@
+package com.github.se.gatherspot.model.event
+
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageBitmapConfig
+import com.github.se.gatherspot.model.Interests
+import com.github.se.gatherspot.model.location.Location
+
+/**
+ * Data class for a draft event. Every field (except for the location, the image and the categories)
+ * is saved as a string.
+ */
+data class DraftEvent(
+    val organiserId: String,
+    val title: String?,
+    val description: String?,
+    val location: Location?,
+    val eventStartDate: String?,
+    val eventEndDate: String?,
+    val timeBeginning: String?,
+    val timeEnding: String?,
+    val attendanceMaxCapacity: String?,
+    val attendanceMinCapacity: String?,
+    val inscriptionLimitDate: String?,
+    val inscriptionLimitTime: String?,
+    val categories: Set<Interests>? = emptySet(),
+    val images: ImageBitmap? = ImageBitmap(30, 30, config = ImageBitmapConfig.Rgb565)
+)

--- a/app/src/main/java/com/github/se/gatherspot/model/utils/JsonCustomsSerializer.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/utils/JsonCustomsSerializer.kt
@@ -2,6 +2,9 @@ package com.github.se.gatherspot.model.utils
 
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.graphics.asImageBitmap
 import com.google.gson.JsonDeserializationContext
 import com.google.gson.JsonDeserializer
 import com.google.gson.JsonElement
@@ -21,7 +24,7 @@ class LocalDateSerializer : JsonSerializer<LocalDate> {
   override fun serialize(
       src: LocalDate,
       typeOfSrc: Type,
-      context: JsonSerializationContext
+      context: JsonSerializationContext?
   ): JsonElement {
     return JsonPrimitive(src.format(DateTimeFormatter.ISO_LOCAL_DATE))
   }
@@ -33,7 +36,7 @@ class LocalDateDeserializer : JsonDeserializer<LocalDate> {
   override fun deserialize(
       json: JsonElement,
       typeOfT: Type,
-      context: JsonDeserializationContext
+      context: JsonDeserializationContext?
   ): LocalDate {
     return LocalDate.parse(json.asString, DateTimeFormatter.ISO_LOCAL_DATE)
   }
@@ -44,7 +47,7 @@ class LocalDateTimeSerializer : JsonSerializer<LocalDateTime> {
   override fun serialize(
       src: LocalDateTime,
       typeOfSrc: Type,
-      context: JsonSerializationContext
+      context: JsonSerializationContext?
   ): JsonElement {
     return JsonPrimitive(src.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
   }
@@ -56,7 +59,7 @@ class LocalDateTimeDeserializer : JsonDeserializer<LocalDateTime> {
   override fun deserialize(
       json: JsonElement,
       typeOfT: Type,
-      context: JsonDeserializationContext
+      context: JsonDeserializationContext?
   ): LocalDateTime {
     return LocalDateTime.parse(json.asString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
   }
@@ -65,14 +68,14 @@ class LocalDateTimeDeserializer : JsonDeserializer<LocalDateTime> {
 /**
  * Custom serializer for Bitmap images
  */
-class BitmapSerializer : JsonSerializer<Bitmap>, JsonDeserializer<Bitmap> {
+class ImageBitmapSerializer : JsonSerializer<ImageBitmap>, JsonDeserializer<ImageBitmap> {
     override fun serialize(
-        src: Bitmap?,
+        src: ImageBitmap?,
         typeOfSrc: Type?,
         context: JsonSerializationContext?
     ): JsonElement {
         return if (src != null) {
-            JsonPrimitive(BitmapImageConverter.fromBitmap(src))
+            JsonPrimitive(ImageBitmapConverter.fromImageBitmap(src))
         } else {
             JsonPrimitive("")
         }
@@ -83,26 +86,30 @@ class BitmapSerializer : JsonSerializer<Bitmap>, JsonDeserializer<Bitmap> {
         json: JsonElement?,
         typeOfT: Type?,
         context: JsonDeserializationContext?
-    ): Bitmap? {
+    ): ImageBitmap? {
         return if (json != null && json.asString.isNotEmpty()) {
-            BitmapImageConverter.toBitmap(json.asString)
+            ImageBitmapConverter.toImageBitmap(json.asString)
         } else {
             null
         }
     }
 }
 
-object BitmapImageConverter {
+object ImageBitmapConverter {
     // Converter for Bitmap to String
-    fun fromBitmap(bitmap: Bitmap): String {
+    fun fromImageBitmap(imageBitmap: ImageBitmap): String {
+        // convert imageBitmap to Bitmap
+        val bitmap = imageBitmap.asAndroidBitmap()
         val byteArrayOutputStream = ByteArrayOutputStream()
         bitmap.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream)
         return Base64.getEncoder().encodeToString(byteArrayOutputStream.toByteArray())
     }
 
     // Converter for String to Bitmap
-    fun toBitmap(stringPicture: String): Bitmap {
+    fun toImageBitmap(stringPicture: String): ImageBitmap {
         val byteArray = Base64.getDecoder().decode(stringPicture)
-        return BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
+        val bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
+        return bitmap.asImageBitmap()
     }
+
 }

--- a/app/src/main/java/com/github/se/gatherspot/model/utils/JsonCustomsSerializer.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/utils/JsonCustomsSerializer.kt
@@ -65,51 +65,48 @@ class LocalDateTimeDeserializer : JsonDeserializer<LocalDateTime> {
   }
 }
 
-/**
- * Custom serializer for Bitmap images
- */
+/** Custom serializer for Bitmap images */
 class ImageBitmapSerializer : JsonSerializer<ImageBitmap>, JsonDeserializer<ImageBitmap> {
-    override fun serialize(
-        src: ImageBitmap?,
-        typeOfSrc: Type?,
-        context: JsonSerializationContext?
-    ): JsonElement {
-        return if (src != null) {
-            JsonPrimitive(ImageBitmapConverter.fromImageBitmap(src))
-        } else {
-            JsonPrimitive("")
-        }
+  override fun serialize(
+      src: ImageBitmap?,
+      typeOfSrc: Type?,
+      context: JsonSerializationContext?
+  ): JsonElement {
+    return if (src != null) {
+      JsonPrimitive(ImageBitmapConverter.fromImageBitmap(src))
+    } else {
+      JsonPrimitive("")
     }
+  }
 
-    @Throws(JsonParseException::class)
-    override fun deserialize(
-        json: JsonElement?,
-        typeOfT: Type?,
-        context: JsonDeserializationContext?
-    ): ImageBitmap? {
-        return if (json != null && json.asString.isNotEmpty()) {
-            ImageBitmapConverter.toImageBitmap(json.asString)
-        } else {
-            null
-        }
+  @Throws(JsonParseException::class)
+  override fun deserialize(
+      json: JsonElement?,
+      typeOfT: Type?,
+      context: JsonDeserializationContext?
+  ): ImageBitmap? {
+    return if (json != null && json.asString.isNotEmpty()) {
+      ImageBitmapConverter.toImageBitmap(json.asString)
+    } else {
+      null
     }
+  }
 }
 
 object ImageBitmapConverter {
-    // Converter for Bitmap to String
-    fun fromImageBitmap(imageBitmap: ImageBitmap): String {
-        // convert imageBitmap to Bitmap
-        val bitmap = imageBitmap.asAndroidBitmap()
-        val byteArrayOutputStream = ByteArrayOutputStream()
-        bitmap.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream)
-        return Base64.getEncoder().encodeToString(byteArrayOutputStream.toByteArray())
-    }
+  // Converter for Bitmap to String
+  fun fromImageBitmap(imageBitmap: ImageBitmap): String {
+    // convert imageBitmap to Bitmap
+    val bitmap = imageBitmap.asAndroidBitmap()
+    val byteArrayOutputStream = ByteArrayOutputStream()
+    bitmap.compress(Bitmap.CompressFormat.PNG, 100, byteArrayOutputStream)
+    return Base64.getEncoder().encodeToString(byteArrayOutputStream.toByteArray())
+  }
 
-    // Converter for String to Bitmap
-    fun toImageBitmap(stringPicture: String): ImageBitmap {
-        val byteArray = Base64.getDecoder().decode(stringPicture)
-        val bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
-        return bitmap.asImageBitmap()
-    }
-
+  // Converter for String to Bitmap
+  fun toImageBitmap(stringPicture: String): ImageBitmap {
+    val byteArray = Base64.getDecoder().decode(stringPicture)
+    val bitmap = BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
+    return bitmap.asImageBitmap()
+  }
 }

--- a/app/src/main/java/com/github/se/gatherspot/ui/EventDataForm.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/EventDataForm.kt
@@ -45,9 +45,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.navigation.compose.rememberNavController
 import com.github.se.gatherspot.firebase.EventFirebaseConnection
 import com.github.se.gatherspot.model.EventUtils
 import com.github.se.gatherspot.model.Interests
@@ -502,12 +500,6 @@ fun Alert(errorTitle: String, errorMessage: String, onDismiss: () -> Unit) {
         Button(onClick = onDismiss, modifier = Modifier.testTag("alertButton")) { Text("OK") }
       },
       dismissButton = {})
-}
-
-@Preview
-@Composable
-fun EventDataFormPreview() {
-  EventDataForm(EventUtils(), NavigationActions(rememberNavController()), EventAction.CREATE)
 }
 
 enum class EventAction {

--- a/app/src/main/java/com/github/se/gatherspot/ui/EventDataForm.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/EventDataForm.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -206,6 +207,30 @@ fun EventDataForm(
                   modifier = Modifier.testTag("clearFieldsButton"),
                   shape = RoundedCornerShape(size = 10.dp)) {
                     Text(text = "Clear all fields")
+                  }
+              Spacer(modifier = Modifier.width(10.dp))
+              // Add a button to save the draft
+              Button(
+                  onClick = {
+                    eventUtils.saveDraftEvent(
+                        title.text,
+                        description.text,
+                        location,
+                        eventStartDate.text,
+                        eventEndDate.text,
+                        eventTimeStart.text,
+                        eventTimeEnd.text,
+                        maxAttendees.text,
+                        minAttendees.text,
+                        inscriptionLimitDate.text,
+                        inscriptionLimitTime.text,
+                        categories.toSet(),
+                        image = null,
+                        context = context)
+                  },
+                  modifier = Modifier.testTag("saveDraftButton"),
+                  shape = RoundedCornerShape(size = 10.dp)) {
+                    Text(text = "Save draft")
                   }
             })
       }) { innerPadding ->

--- a/app/src/main/java/com/github/se/gatherspot/ui/EventDataForm.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/EventDataForm.kt
@@ -41,6 +41,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
@@ -125,6 +126,23 @@ fun EventDataForm(
     minAttendees = TextFieldValue(event.attendanceMinCapacity.toString())
     inscriptionLimitDate = TextFieldValue(event.inscriptionLimitDate?.format(dateFormatter) ?: "")
     inscriptionLimitTime = TextFieldValue(event.inscriptionLimitTime?.format(timeFormatter) ?: "")
+  }
+
+  val draft = eventUtils.retrieveFromDraft(LocalContext.current)
+  if (eventAction == EventAction.CREATE && draft != null) {
+    // Restore the draft
+    title = TextFieldValue(draft.title ?: "")
+    description = TextFieldValue(draft.description ?: "")
+    location = draft.location
+    eventStartDate = TextFieldValue(draft.eventStartDate ?: "")
+    eventEndDate = TextFieldValue(draft.eventEndDate ?: "")
+    eventTimeStart = TextFieldValue(draft.timeBeginning ?: "")
+    eventTimeEnd = TextFieldValue(draft.timeEnding ?: "")
+    maxAttendees = TextFieldValue(draft.attendanceMaxCapacity ?: "")
+    minAttendees = TextFieldValue(draft.attendanceMinCapacity ?: "")
+    inscriptionLimitDate = TextFieldValue(draft.inscriptionLimitDate ?: "")
+    inscriptionLimitTime = TextFieldValue(draft.inscriptionLimitTime ?: "")
+    categories.addAll(draft.categories ?: emptySet())
   }
 
   Scaffold(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ lifecycleRuntimeKtx = "2.7.0"
 activityCompose = "1.8.2"
 composeBom = "2023.08.00"
 firebaseStorageKtx = "20.3.0"
+coreAnimation = "1.0.0-rc01"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -26,6 +27,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 firebase-storage-ktx = { group = "com.google.firebase", name = "firebase-storage-ktx", version.ref = "firebaseStorageKtx" }
+androidx-core-animation = { group = "androidx.core", name = "core-animation", version.ref = "coreAnimation" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
In this PR, I have implemented the draft event feature. When someone start to create an event and don't finish, the draft will be saved locally in the storage of the phone.
Here's the main changes

* Add 2 buttons on EventDataForm composable
* Implement the functionalites to store a draftEvent in the local storage (store, load and delete functions)
* Implement functions in EventUtils that call the LocalStorage functions
* Testing of these new features



Once merged, it will closes #111 