### PR TITLE
Adding Chronological Logic to events

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,304 +1,277 @@
 plugins {
-    id("com.android.application")
-    id("com.google.gms.google-services")
-    id ("org.jetbrains.kotlin.android")
-    id("com.ncorti.ktfmt.gradle") version "0.16.0"
-    id("jacoco")
-    id("org.sonarqube") version "4.4.1.3373"
-    id ("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
+  id("com.android.application")
+  id("com.google.gms.google-services")
+  id("org.jetbrains.kotlin.android")
+  id("com.ncorti.ktfmt.gradle") version "0.16.0"
+  id("jacoco")
+  id("org.sonarqube") version "4.4.1.3373"
+  id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
 }
 
 secrets {
-    // Optionally specify a different file name containing your secrets.
-    // The plugin defaults to "local.properties"
-    propertiesFileName = "secrets.properties"
+  // Optionally specify a different file name containing your secrets.
+  // The plugin defaults to "local.properties"
+  propertiesFileName = "secrets.properties"
 
-    // A properties file containing default secret values. This file can be
-    // checked in version control.
-    defaultPropertiesFileName = "local.defaults.properties"
+  // A properties file containing default secret values. This file can be
+  // checked in version control.
+  defaultPropertiesFileName = "local.defaults.properties"
 }
 
 android {
-    namespace = "com.github.se.gatherspot"
-    compileSdk = 34
-    packagingOptions {
-        exclude("META-INF/LICENSE.md")
-        exclude("META-INF/LICENSE-notice.md")
-    }
-    testCoverage {
-        jacocoVersion = "0.8.8"
-    }
+  namespace = "com.github.se.gatherspot"
+  compileSdk = 34
+  packagingOptions {
+    exclude("META-INF/LICENSE.md")
+    exclude("META-INF/LICENSE-notice.md")
+  }
+  testCoverage { jacocoVersion = "0.8.8" }
 
-    sonar {
-        properties {
-            property("sonar.projectKey", "GatherSpot_MobileApp")
-            property("sonar.projectName", "MobileApp")
-            property("sonar.organization", "gatherspot")
-            property("sonar.host.url", "https://sonarcloud.io")
-            // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
-            property(
-                "sonar.junit.reportPaths",
-                "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/"
-            )
-            // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.
-            property(
-                "sonar.androidLint.reportPaths",
-                "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml"
-            )
-            // Paths to JaCoCo XML coverage report files.
-            property(
-                "sonar.coverage.jacoco.xmlReportPaths",
-                "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml"
-            )
-        }
+  sonar {
+    properties {
+      property("sonar.projectKey", "GatherSpot_MobileApp")
+      property("sonar.projectName", "MobileApp")
+      property("sonar.organization", "gatherspot")
+      property("sonar.host.url", "https://sonarcloud.io")
+      // Comma-separated paths to the various directories containing the *.xml JUnit report files.
+      // Each path may be absolute or relative to the project base directory.
+      property(
+          "sonar.junit.reportPaths",
+          "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
+      // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will
+      // have to be changed too.
+      property(
+          "sonar.androidLint.reportPaths",
+          "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
+      // Paths to JaCoCo XML coverage report files.
+      property(
+          "sonar.coverage.jacoco.xmlReportPaths",
+          "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
     }
-    defaultConfig {
-        applicationId = "com.github.se.gatherspot"
-        minSdk = 29
-        targetSdk = 34
-        versionCode = 1
-        versionName = "1.0"
+  }
+  defaultConfig {
+    applicationId = "com.github.se.gatherspot"
+    minSdk = 29
+    targetSdk = 34
+    versionCode = 1
+    versionName = "1.0"
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        vectorDrawables {
-            useSupportLibrary = true
-        }
-    }
+    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    vectorDrawables { useSupportLibrary = true }
+  }
 
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-        debug {
-            enableUnitTestCoverage = true
-            enableAndroidTestCoverage = true
-        }
+  buildTypes {
+    release {
+      isMinifyEnabled = false
+      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+    debug {
+      enableUnitTestCoverage = true
+      enableAndroidTestCoverage = true
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-    buildFeatures {
-        compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
-    packaging {
-        resources {
-            excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
+  }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+  }
+  kotlinOptions { jvmTarget = "1.8" }
+  buildFeatures { compose = true }
+  composeOptions { kotlinCompilerExtensionVersion = "1.5.1" }
+  packaging { resources { excludes += "/META-INF/{AL2.0,LGPL2.1}" } }
 }
 
 dependencies {
 
-    // ---------------------- </IMPLEMENTATION ------------------
-    //</ Android COMPOSE
-    implementation("androidx.compose.runtime:runtime-livedata")
-    implementation("androidx.activity:activity-compose:1.8.2")
-    implementation("androidx.compose.ui:ui-graphics")
-    implementation("androidx.compose.ui:ui:1.4.0")
-    implementation("androidx.compose.ui:ui-tooling-preview:1.4.0")
-    implementation("androidx.compose.material:material")
-    implementation("androidx.compose.material3:material3")
-    implementation("androidx.compose.material:material:1.6.2") //necessary for EventUI Automirrored to work
-    implementation(platform("androidx.compose:compose-bom:2023.08.00"))
-    ///>
+  // ---------------------- </IMPLEMENTATION ------------------
+  // </ Android COMPOSE
+  implementation("androidx.compose.runtime:runtime-livedata")
+  implementation("androidx.activity:activity-compose:1.8.2")
+  implementation("androidx.compose.ui:ui-graphics")
+  implementation("androidx.compose.ui:ui:1.4.0")
+  implementation("androidx.compose.ui:ui-tooling-preview:1.4.0")
+  implementation("androidx.compose.material:material")
+  implementation("androidx.compose.material3:material3")
+  implementation(
+      "androidx.compose.material:material:1.6.2") // necessary for EventUI Automirrored to work
+  implementation(platform("androidx.compose:compose-bom:2023.08.00"))
+  /// >
 
-    //</firebase
-    implementation(platform("com.google.firebase:firebase-bom:32.8.1")) //changed to newer version
-    implementation("com.google.firebase:firebase-analytics")
-    implementation("com.google.firebase:firebase-database")
-    implementation("com.google.firebase:firebase-firestore")
-    implementation("com.google.firebase:firebase-auth")
-    implementation("com.firebaseui:firebase-ui-auth:7.2.0") // Can't find it anywhere
-    ///>
+  // </firebase
+  implementation(platform("com.google.firebase:firebase-bom:32.8.1")) // changed to newer version
+  implementation("com.google.firebase:firebase-analytics")
+  implementation("com.google.firebase:firebase-database")
+  implementation("com.google.firebase:firebase-firestore")
+  implementation("com.google.firebase:firebase-auth")
+  implementation("com.firebaseui:firebase-ui-auth:7.2.0") // Can't find it anywhere
+  /// >
 
-    //</Used for uploading images
-    implementation ("com.google.firebase:firebase-storage")
-    implementation("androidx.fragment:fragment:1.5.5")
-    implementation("com.squareup.okhttp3:okhttp:3.10.0")
-    ///>
+  // </Used for uploading images
+  implementation("com.google.firebase:firebase-storage")
+  implementation("androidx.fragment:fragment:1.5.5")
+  implementation("com.squareup.okhttp3:okhttp:3.10.0")
+  /// >
 
+  // <gson
+  implementation("com.google.code.gson:gson:2.10.1")
+  /// >
 
-    //<gson
-    implementation("com.google.code.gson:gson:2.10.1")
-    ///>
+  // </Android navigation
+  implementation("androidx.navigation:navigation-compose:2.6.0-rc01")
+  implementation("androidx.navigation:navigation-fragment-ktx:2.7.5")
+  implementation("androidx.navigation:navigation-ui-ktx:2.7.5")
 
-    //</Android navigation
-    implementation("androidx.navigation:navigation-compose:2.6.0-rc01")
-    implementation("androidx.navigation:navigation-fragment-ktx:2.7.5")
-    implementation("androidx.navigation:navigation-ui-ktx:2.7.5")
+  /// >
 
-    ///>
+  // </Google Maps
+  implementation("com.google.maps.android:maps-compose:4.3.0")
+  implementation("com.google.maps.android:maps-compose-utils:4.3.0")
+  /// >
 
-    //</Google Maps
-    implementation("com.google.maps.android:maps-compose:4.3.0")
-    implementation("com.google.maps.android:maps-compose-utils:4.3.0")
-    ///>
+  // </gms play
+  implementation("com.google.android.gms:play-services-auth:20.6.0")
+  implementation("com.google.android.gms:play-services-maps:18.1.0")
+  /// >
 
-    //</gms play
-    implementation("com.google.android.gms:play-services-auth:20.6.0")
-    implementation("com.google.android.gms:play-services-maps:18.1.0")
-    ///>
+  // </coil
+  implementation("io.coil-kt:coil-compose:2.6.0")
+  /// >
 
-    //</coil
-    implementation("io.coil-kt:coil-compose:2.6.0")
-    ///>
+  implementation("androidx.appcompat:appcompat:1.6.1")
 
+  // QR Code
+  // ZXing Core
+  implementation("com.google.zxing:core:3.5.1")
+  // ZXing Android Embedded (for scanning)
+  implementation("com.journeyapps:zxing-android-embedded:4.3.0")
 
-    implementation("androidx.appcompat:appcompat:1.6.1")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
 
-    //QR Code
-    // ZXing Core
-    implementation ("com.google.zxing:core:3.5.1")
-    // ZXing Android Embedded (for scanning)
-    implementation ("com.journeyapps:zxing-android-embedded:4.3.0")
+  implementation("com.squareup.okhttp3:okhttp:3.10.0")
+  implementation("com.squareup.okhttp3:okhttp:4.9.0") // For location //DOUBLON
 
+  implementation("androidx.core:core-ktx:1.7.0")
+  implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
+  implementation("com.google.android.play:core-ktx:1.7.0")
 
+  implementation("com.google.android.material:material:1.10.0") // Different than compose:material ?
+  implementation("androidx.constraintlayout:constraintlayout:2.1.4")
 
+  implementation("androidx.compose.ui:ui-graphics")
 
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
-
-
-    implementation("com.squareup.okhttp3:okhttp:3.10.0")
-    implementation("com.squareup.okhttp3:okhttp:4.9.0") //For location //DOUBLON
-
-
-    implementation("androidx.core:core-ktx:1.7.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
-    implementation("com.google.android.play:core-ktx:1.7.0")
-
-
-
-
-    implementation("com.google.android.material:material:1.10.0") //Different than compose:material ?
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-
-    implementation("androidx.compose.ui:ui-graphics")
-
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
+  implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
   //  implementation(libs.androidx.core.animation)
 
+  // ---------------------- /IMPLEMENTATION> ------------------
 
-    // ---------------------- /IMPLEMENTATION> ------------------
+  // DEBUG IMPLEMENTATION DEPENDENCIES
 
+  debugImplementation("androidx.compose.ui:ui-tooling:1.4.0")
+  debugImplementation("androidx.compose.ui:ui-test-manifest:1.4.0")
 
-    // DEBUG IMPLEMENTATION DEPENDENCIES
+  // TEST IMPLEMENTATION DEPENDENCIES
 
-    debugImplementation("androidx.compose.ui:ui-tooling:1.4.0")
-    debugImplementation("androidx.compose.ui:ui-test-manifest:1.4.0")
+  testImplementation("junit:junit:4.13.2")
+  testImplementation("org.mockito:mockito-core:3.11.2")
+  testImplementation("org.mockito:mockito-inline:2.13.0")
+  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
 
+  // ANDROID TEST IMPLEMENTATION DEPENDENCIES
 
-    // TEST IMPLEMENTATION DEPENDENCIES
+  androidTestImplementation("androidx.test.ext:junit:1.1.5")
+  androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+  androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.4.0")
+  // Dependency for using Intents in instrumented tests
+  androidTestImplementation("androidx.test.espresso:espresso-intents:3.5.1")
+  androidTestImplementation(platform("androidx.compose:compose-bom:2023.08.00"))
 
-    testImplementation("junit:junit:4.13.2")
-    testImplementation("org.mockito:mockito-core:3.11.2")
-    testImplementation("org.mockito:mockito-inline:2.13.0")
-    testImplementation ("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
+  androidTestImplementation("com.kaspersky.android-components:kaspresso:1.4.3")
+  // Allure support
+  androidTestImplementation("com.kaspersky.android-components:kaspresso-allure-support:1.4.3")
+  // Jetpack Compose support
+  androidTestImplementation("com.kaspersky.android-components:kaspresso-compose-support:1.4.1")
 
+  // </ Dependencies for using MockK in instrumented tests
+  androidTestImplementation("io.mockk:mockk:1.13.7")
+  androidTestImplementation("io.mockk:mockk-android:1.13.7")
+  androidTestImplementation("io.mockk:mockk-agent:1.13.7")
+  androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
+  /// >
 
-    // ANDROID TEST IMPLEMENTATION DEPENDENCIES
+  androidTestImplementation("org.mockito:mockito-core:3.11.2")
+  androidTestImplementation("org.mockito:mockito-inline:2.13.0")
+  androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
+  androidTestImplementation("androidx.test.ext:junit:1.1.5")
+  androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+  androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.4.0")
+  androidTestImplementation(platform("androidx.compose:compose-bom:2023.08.00"))
+  androidTestImplementation("com.kaspersky.android-components:kaspresso:1.4.3")
+  // Allure support
+  androidTestImplementation("com.kaspersky.android-components:kaspresso-allure-support:1.4.3")
+  // Jetpack Compose support
+  androidTestImplementation("com.kaspersky.android-components:kaspresso-compose-support:1.4.1")
+  androidTestImplementation("com.google.firebase:firebase-database")
+  androidTestImplementation("com.google.firebase:firebase-firestore")
 
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.4.0")
-    // Dependency for using Intents in instrumented tests
-    androidTestImplementation("androidx.test.espresso:espresso-intents:3.5.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2023.08.00"))
-
-
-    androidTestImplementation("com.kaspersky.android-components:kaspresso:1.4.3")
-    // Allure support
-    androidTestImplementation("com.kaspersky.android-components:kaspresso-allure-support:1.4.3")
-    // Jetpack Compose support
-    androidTestImplementation("com.kaspersky.android-components:kaspresso-compose-support:1.4.1")
-
-
-    //</ Dependencies for using MockK in instrumented tests
-    androidTestImplementation("io.mockk:mockk:1.13.7")
-    androidTestImplementation("io.mockk:mockk-android:1.13.7")
-    androidTestImplementation("io.mockk:mockk-agent:1.13.7")
-    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
-    ///>
-
-
-
-    androidTestImplementation("org.mockito:mockito-core:3.11.2")
-    androidTestImplementation("org.mockito:mockito-inline:2.13.0")
-    androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.4.0")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2023.08.00"))
-    androidTestImplementation("com.kaspersky.android-components:kaspresso:1.4.3")
-    // Allure support
-    androidTestImplementation("com.kaspersky.android-components:kaspresso-allure-support:1.4.3")
-    // Jetpack Compose support
-    androidTestImplementation("com.kaspersky.android-components:kaspresso-compose-support:1.4.1")
-    androidTestImplementation("com.google.firebase:firebase-database")
-    androidTestImplementation("com.google.firebase:firebase-firestore")
-
-    // Image fetching library
-    implementation("io.coil-kt:coil-compose:2.6.0")
+  // Image fetching library
+  implementation("io.coil-kt:coil-compose:2.6.0")
 }
+
 tasks.withType<Test> {
-    // Configure Jacoco for each tests
-    configure<JacocoTaskExtension> {
-        isIncludeNoLocationClasses = true
-        excludes = listOf("jdk.internal.*")
-    }
+  // Configure Jacoco for each tests
+  configure<JacocoTaskExtension> {
+    isIncludeNoLocationClasses = true
+    excludes = listOf("jdk.internal.*")
+  }
 }
+
 tasks.register("jacocoTestReport", JacocoReport::class) {
-    mustRunAfter("testDebugUnitTest", "connectedDebugAndroidTest")
+  mustRunAfter("testDebugUnitTest", "connectedDebugAndroidTest")
 
-    reports {
-        xml.required = true
-        html.required = true
-    }
+  reports {
+    xml.required = true
+    html.required = true
+  }
 
-    val fileFilter = listOf(
-        "**/R.class",
-        "**/R$*.class",
-        "**/BuildConfig.*",
-        "**/Manifest*.*",
-        "**/*Test*.*",
-        "android/**/*.*",
-    )
-    val debugTree = fileTree("${project.buildDir}/tmp/kotlin-classes/debug") {
-        exclude(fileFilter)
-    }
-    val mainSrc = "${project.projectDir}/src/main/java"
+  val fileFilter =
+      listOf(
+          "**/R.class",
+          "**/R$*.class",
+          "**/BuildConfig.*",
+          "**/Manifest*.*",
+          "**/*Test*.*",
+          "android/**/*.*",
+      )
+  val debugTree = fileTree("${project.buildDir}/tmp/kotlin-classes/debug") { exclude(fileFilter) }
+  val mainSrc = "${project.projectDir}/src/main/java"
 
-    sourceDirectories.setFrom(files(mainSrc))
-    classDirectories.setFrom(files(debugTree))
-    executionData.setFrom(fileTree(project.buildDir) {
+  sourceDirectories.setFrom(files(mainSrc))
+  classDirectories.setFrom(files(debugTree))
+  executionData.setFrom(
+      fileTree(project.buildDir) {
         include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
         include("outputs/code_coverage/debugAndroidTest/connected/*/coverage.ec")
-    })
+      })
 }
 
-sonar{
-    properties {
-        property("sonar.projectKey", "GatherSpot_MobileApp")
-        property("sonar.projectName", "MobileApp")
-        property("sonar.organization", "gatherspot")
-        property("sonar.host.url", "https://sonarcloud.io")
-        // Comma-separated paths to the various directories containing the *.xml JUnit report files. Each path may be absolute or relative to the project base directory.
-        property("sonar.junit.reportPaths", "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
-        // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will have to be changed too.
-        property("sonar.androidLint.reportPaths", "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
-        // Paths to JaCoCo XML coverage report files.
-        property("sonar.coverage.jacoco.xmlReportPaths", "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
-    }
-
+sonar {
+  properties {
+    property("sonar.projectKey", "GatherSpot_MobileApp")
+    property("sonar.projectName", "MobileApp")
+    property("sonar.organization", "gatherspot")
+    property("sonar.host.url", "https://sonarcloud.io")
+    // Comma-separated paths to the various directories containing the *.xml JUnit report files.
+    // Each path may be absolute or relative to the project base directory.
+    property(
+        "sonar.junit.reportPaths",
+        "${project.layout.buildDirectory.get()}/test-results/testDebugunitTest/")
+    // Paths to xml files with Android Lint issues. If the main flavor is changed, this file will
+    // have to be changed too.
+    property(
+        "sonar.androidLint.reportPaths",
+        "${project.layout.buildDirectory.get()}/reports/lint-results-debug.xml")
+    // Paths to JaCoCo XML coverage report files.
+    property(
+        "sonar.coverage.jacoco.xmlReportPaths",
+        "${project.layout.buildDirectory.get()}/reports/jacoco/jacocoTestReport/jacocoTestReport.xml")
+  }
 }
-

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -185,7 +185,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-graphics")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.2")
-    implementation(libs.androidx.core.animation)
+  //  implementation(libs.androidx.core.animation)
 
 
     // ---------------------- /IMPLEMENTATION> ------------------

--- a/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
@@ -21,19 +21,19 @@ import org.junit.Test
 
 class EventFirebaseConnectionTest {
 
-  val EventFirebaseConnection = EventFirebaseConnection()
+  val eventFirebaseConnection = EventFirebaseConnection()
 
   @Test
   fun testgetID() {
-    val newId = EventFirebaseConnection.getNewID()
+    val newId = eventFirebaseConnection.getNewID()
     assertNotNull(newId)
     assertTrue(newId.isNotEmpty())
   }
 
   @Test
   fun testUniquegetID() {
-    val newId1 = EventFirebaseConnection.getNewID()
-    val newId2 = EventFirebaseConnection.getNewID()
+    val newId1 = eventFirebaseConnection.getNewID()
+    val newId2 = eventFirebaseConnection.getNewID()
     assertNotNull(newId1)
     assertNotNull(newId2)
     assertNotEquals(newId1, newId2)
@@ -41,7 +41,7 @@ class EventFirebaseConnectionTest {
 
   @Test
   fun testAddAndFetchEvent() = runTest {
-    val eventID = EventFirebaseConnection.getNewID()
+    val eventID = eventFirebaseConnection.getNewID()
     val event =
         Event(
             id = eventID,
@@ -50,10 +50,12 @@ class EventFirebaseConnectionTest {
             location = Location(0.0, 0.0, "Test Location"),
             eventStartDate =
                 LocalDate.parse(
-                    "12/04/2026", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                    "12/04/2026",
+                    DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
             eventEndDate =
                 LocalDate.parse(
-                    "12/05/2026", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                    "12/05/2026",
+                    DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
             timeBeginning =
                 LocalTime.parse(
                     "10:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
@@ -64,7 +66,8 @@ class EventFirebaseConnectionTest {
             attendanceMinCapacity = 10,
             inscriptionLimitDate =
                 LocalDate.parse(
-                    "10/04/2025", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                    "10/04/2025",
+                    DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
             inscriptionLimitTime =
                 LocalTime.parse(
                     "09:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
@@ -75,9 +78,9 @@ class EventFirebaseConnectionTest {
             images = null,
             globalRating = null)
 
-    EventFirebaseConnection.add(event)
+    eventFirebaseConnection.add(event)
     var resultEvent: Event? = null
-    async { resultEvent = EventFirebaseConnection.fetch(eventID) as Event? }.await()
+    async { resultEvent = eventFirebaseConnection.fetch(eventID) as Event? }.await()
     assertNotNull(resultEvent)
     assertEquals(resultEvent!!.id, eventID)
     assertEquals(resultEvent!!.title, "Test Event")
@@ -89,11 +92,13 @@ class EventFirebaseConnectionTest {
     assertEquals(
         resultEvent!!.eventStartDate,
         LocalDate.parse(
-            "12/04/2026", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)))
+            "12/04/2026",
+            DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)))
     assertEquals(
         resultEvent!!.eventEndDate,
         LocalDate.parse(
-            "12/05/2026", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)))
+            "12/05/2026",
+            DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)))
     assertEquals(
         resultEvent!!.timeBeginning,
         LocalTime.parse("10:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)))
@@ -105,7 +110,8 @@ class EventFirebaseConnectionTest {
     assertEquals(
         resultEvent!!.inscriptionLimitDate,
         LocalDate.parse(
-            "10/04/2025", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)))
+            "10/04/2025",
+            DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)))
     assertEquals(
         resultEvent!!.inscriptionLimitTime,
         LocalTime.parse("09:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)))
@@ -114,13 +120,13 @@ class EventFirebaseConnectionTest {
     assertEquals(resultEvent!!.registeredUsers!!.size, 0)
     assertEquals(resultEvent!!.finalAttendees!!.size, 0)
     assertEquals(resultEvent!!.images, null)
-    EventFirebaseConnection.delete(eventID)
+    eventFirebaseConnection.delete(eventID)
   }
 
   @Test
   fun fetchReturnsNull() = runTest {
     // Supposing that id will never equal nonexistent
-    val event = EventFirebaseConnection.fetch("nonexistent")
+    val event = eventFirebaseConnection.fetch("nonexistent")
     assertEquals(event, null)
   }
 
@@ -128,16 +134,16 @@ class EventFirebaseConnectionTest {
   fun fetchNextReturnsDistinctEvents() =
       runTest(timeout = Duration.parse("20s")) {
         val round = 5
-        val listOfEvents1 = EventFirebaseConnection.fetchNextEvents(round.toLong())
+        val listOfEvents1 = eventFirebaseConnection.fetchNextEvents(round.toLong())
         assert(round >= listOfEvents1.size)
-        val listOfEvents2 = EventFirebaseConnection.fetchNextEvents(round.toLong())
+        val listOfEvents2 = eventFirebaseConnection.fetchNextEvents(round.toLong())
         assert(round >= listOfEvents2.size)
         for (i in 0 until listOfEvents1.size) {
           for (j in 0 until listOfEvents2.size) {
             assertNotEquals(listOfEvents1[i].id, listOfEvents2[j].id)
           }
         }
-        EventFirebaseConnection.offset = null
+        eventFirebaseConnection.offset = null
       }
 
   @Test
@@ -147,9 +153,9 @@ class EventFirebaseConnectionTest {
         val round = 5
         val interests = listOf(Interests.CHESS, Interests.BASKETBALL)
         val listOfEvents1 =
-            EventFirebaseConnection.fetchEventsBasedOnInterests(round.toLong(), interests)
+            eventFirebaseConnection.fetchEventsBasedOnInterests(round.toLong(), interests)
         val listOfEvents2 =
-            EventFirebaseConnection.fetchEventsBasedOnInterests(round.toLong(), interests)
+            eventFirebaseConnection.fetchEventsBasedOnInterests(round.toLong(), interests)
         for (i in 0 until listOfEvents1.size) {
           assertNotNull(listOfEvents1[i].categories)
           assertTrue(
@@ -164,7 +170,7 @@ class EventFirebaseConnectionTest {
         }
 
         testLoginCleanUp()
-        EventFirebaseConnection.offset = null
+        eventFirebaseConnection.offset = null
       }
 
   @Test
@@ -174,16 +180,16 @@ class EventFirebaseConnectionTest {
         val round = 5
         val interests = listOf(Interests.CHESS, Interests.BASKETBALL)
         val listOfEvents1 =
-            EventFirebaseConnection.fetchEventsBasedOnInterests(round.toLong(), interests)
+            eventFirebaseConnection.fetchEventsBasedOnInterests(round.toLong(), interests)
         val listOfEvents2 =
-            EventFirebaseConnection.fetchEventsBasedOnInterests(round.toLong(), interests)
+            eventFirebaseConnection.fetchEventsBasedOnInterests(round.toLong(), interests)
         for (i in 0 until listOfEvents1.size) {
           for (j in 0 until listOfEvents2.size) {
             assertNotEquals(listOfEvents1[i].id, listOfEvents2[j].id)
           }
         }
         testLoginCleanUp()
-        EventFirebaseConnection.offset = null
+        eventFirebaseConnection.offset = null
       }
 
   @Test
@@ -191,7 +197,7 @@ class EventFirebaseConnectionTest {
       runTest(timeout = Duration.parse("20s")) {
         testLogin()
         Thread.sleep(10000)
-        val events = EventFirebaseConnection.fetchMyEvents()
+        val events = eventFirebaseConnection.fetchMyEvents()
         assert(
             events.all { event ->
               event.organizerID == FirebaseAuth.getInstance().currentUser!!.uid
@@ -204,7 +210,7 @@ class EventFirebaseConnectionTest {
       runTest(timeout = Duration.parse("20s")) {
         testLogin()
         Thread.sleep(10000)
-        val events = EventFirebaseConnection.fetchRegisteredTo()
+        val events = eventFirebaseConnection.fetchRegisteredTo()
         assert(
             events.all { event ->
               event.registeredUsers.contains(FirebaseAuth.getInstance().currentUser!!.uid)
@@ -214,7 +220,7 @@ class EventFirebaseConnectionTest {
 
   @Test
   fun deleteEvent() = runTest {
-    val eventID = EventFirebaseConnection.getNewID()
+    val eventID = eventFirebaseConnection.getNewID()
     val event =
         Event(
             id = eventID,
@@ -223,10 +229,12 @@ class EventFirebaseConnectionTest {
             location = Location(0.0, 0.0, "Test Location"),
             eventStartDate =
                 LocalDate.parse(
-                    "12/04/2026", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                    "12/04/2026",
+                    DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
             eventEndDate =
                 LocalDate.parse(
-                    "12/05/2026", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                    "12/05/2026",
+                    DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
             timeBeginning =
                 LocalTime.parse(
                     "10:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
@@ -237,7 +245,8 @@ class EventFirebaseConnectionTest {
             attendanceMinCapacity = 10,
             inscriptionLimitDate =
                 LocalDate.parse(
-                    "10/04/2025", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                    "10/04/2025",
+                    DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
             inscriptionLimitTime =
                 LocalTime.parse(
                     "09:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
@@ -248,19 +257,19 @@ class EventFirebaseConnectionTest {
             images = null,
             globalRating = null)
 
-    EventFirebaseConnection.add(event)
+    eventFirebaseConnection.add(event)
     var resultEvent: Event? = null
-    async { resultEvent = EventFirebaseConnection.fetch(eventID) as Event? }.await()
+    async { resultEvent = eventFirebaseConnection.fetch(eventID) as Event? }.await()
     assertNotNull(resultEvent)
     assertEquals(resultEvent!!.id, eventID)
-    EventFirebaseConnection.delete(eventID)
-    async { resultEvent = EventFirebaseConnection.fetch(eventID) as Event? }.await()
+    eventFirebaseConnection.delete(eventID)
+    async { resultEvent = eventFirebaseConnection.fetch(eventID) as Event? }.await()
     assertEquals(resultEvent, null)
   }
 
   @Test
   fun nullCasesTest() = runTest {
-    val eventID = EventFirebaseConnection.getNewID()
+    val eventID = eventFirebaseConnection.getNewID()
     val event =
         Event(
             id = eventID,
@@ -282,9 +291,9 @@ class EventFirebaseConnectionTest {
             images = null,
             globalRating = null)
 
-    EventFirebaseConnection.add(event)
+    eventFirebaseConnection.add(event)
     var resultEvent: Event? = null
-    async { resultEvent = EventFirebaseConnection.fetch(eventID) as Event? }.await()
+    async { resultEvent = eventFirebaseConnection.fetch(eventID) as Event? }.await()
     assertNotNull(resultEvent)
     assertEquals(resultEvent!!.id, eventID)
     assertEquals(resultEvent!!.title, "Test Event")
@@ -303,18 +312,18 @@ class EventFirebaseConnectionTest {
     assertEquals(resultEvent!!.registeredUsers!!.size, 0)
     assertEquals(resultEvent!!.finalAttendees!!.size, 0)
     assertEquals(resultEvent!!.images, null)
-    EventFirebaseConnection.delete(eventID)
+    eventFirebaseConnection.delete(eventID)
   }
 
   @Test
   fun mapStringToTimeTest() = runTest {
-    val time = EventFirebaseConnection.mapTimeStringToTime("Not good format")
+    val time = eventFirebaseConnection.mapTimeStringToTime("Not good format")
     assertEquals(time, null)
   }
 
   @Test
   fun mapStringToDateTest() = runTest {
-    val date = EventFirebaseConnection.mapDateStringToDate("Not good format")
+    val date = eventFirebaseConnection.mapDateStringToDate("Not good format")
     assertEquals(date, null)
   }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/model/EventTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/model/EventTest.kt
@@ -1,0 +1,66 @@
+package com.github.se.gatherspot.model
+
+import androidx.compose.ui.graphics.ImageBitmap
+import com.github.se.gatherspot.model.event.Event
+import com.github.se.gatherspot.model.utils.ImageBitmapSerializer
+import com.github.se.gatherspot.model.utils.LocalDateDeserializer
+import com.github.se.gatherspot.model.utils.LocalDateSerializer
+import com.github.se.gatherspot.model.utils.LocalTimeDeserializer
+import com.github.se.gatherspot.model.utils.LocalTimeSerializer
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+import java.time.LocalDate
+import java.time.LocalTime
+import org.junit.Test
+
+class EventTest {
+
+  @Test
+  fun testToJson() {
+    val event =
+        Event(
+            id = "1",
+            title = "Testing toJson()",
+            description = "I have to be converted to Json",
+            attendanceMaxCapacity = 10,
+            attendanceMinCapacity = 1,
+            organizerID = Profile.testParticipant().id,
+            categories = setOf(Interests.BOWLING),
+            eventEndDate = LocalDate.of(2024, 4, 15),
+            eventStartDate = LocalDate.of(2024, 4, 14),
+            globalRating = 4,
+            inscriptionLimitDate = LocalDate.of(2024, 4, 11),
+            inscriptionLimitTime = LocalTime.of(23, 59),
+            location = null,
+            registeredUsers = mutableListOf(),
+            timeBeginning = LocalTime.of(13, 0),
+            timeEnding = LocalTime.of(16, 0),
+        )
+
+    val json = event.toJson()
+
+    val gson: Gson =
+        GsonBuilder()
+            .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
+            .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
+            .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
+            .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+            .registerTypeAdapter(ImageBitmap::class.java, ImageBitmapSerializer())
+            .create()
+
+    val decodedJson = URLDecoder.decode(json, StandardCharsets.US_ASCII.toString())
+    val eventObject = gson.fromJson(decodedJson, Event::class.java)
+    assert(eventObject.id == "1")
+    assert(eventObject.title == "Testing toJson()")
+    assert(eventObject.description == "I have to be converted to Json")
+    assert(eventObject.organizerID == Profile.testParticipant().id)
+    assert(eventObject.attendanceMinCapacity == 1)
+    assert(eventObject.attendanceMaxCapacity == 10)
+    assert(eventObject.eventStartDate == LocalDate.of(2024, 4, 14))
+    assert(eventObject.eventEndDate == LocalDate.of(2024, 4, 15))
+    assert(eventObject.timeBeginning == LocalTime.of(13, 0))
+    assert(eventObject.timeEnding == LocalTime.of(16, 0))
+  }
+}

--- a/app/src/androidTest/java/com/github/se/gatherspot/model/EventUtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/model/EventUtilsTest.kt
@@ -16,7 +16,7 @@ import org.junit.Assert
 import org.junit.Test
 
 class EventUtilsTest {
-  private val EventFirebaseConnection = EventFirebaseConnection()
+  private val eventFirebaseConnection = EventFirebaseConnection()
   private val testEvent =
       Event(
           id = "testID",
@@ -25,10 +25,12 @@ class EventUtilsTest {
           location = Location(0.0, 0.0, "Test Location"),
           eventStartDate =
               LocalDate.parse(
-                  "12/04/2026", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                  "12/04/2026",
+                  DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
           eventEndDate =
               LocalDate.parse(
-                  "12/05/2026", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                  "12/05/2026",
+                  DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
           timeBeginning =
               LocalTime.parse(
                   "10:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
@@ -39,7 +41,8 @@ class EventUtilsTest {
           attendanceMinCapacity = 10,
           inscriptionLimitDate =
               LocalDate.parse(
-                  "10/04/2025", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                  "10/04/2025",
+                  DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
           inscriptionLimitTime =
               LocalTime.parse(
                   "12:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
@@ -82,7 +85,7 @@ class EventUtilsTest {
     Assert.assertEquals(LocalTime.of(9, 0), event.inscriptionLimitTime)
 
     // Keep a clean database: suppress immediately the event
-    EventFirebaseConnection.delete(event.id)
+    eventFirebaseConnection.delete(event.id)
   }
 
   @Test
@@ -120,7 +123,7 @@ class EventUtilsTest {
     Assert.assertEquals(LocalTime.of(9, 0), event.inscriptionLimitTime)
 
     // Keep a clean database: suppress immediately the event
-    EventFirebaseConnection.delete(event.id)
+    eventFirebaseConnection.delete(event.id)
   }
 
   @Test
@@ -481,12 +484,12 @@ class EventUtilsTest {
             timeEnding = LocalTime.of(16, 0),
         )
     val eventUtils = EventUtils()
-    EventFirebaseConnection.add(event)
-    val eventFromDB = runBlocking { EventFirebaseConnection.fetch("myEventToDelete") }
+    eventFirebaseConnection.add(event)
+    val eventFromDB = runBlocking { eventFirebaseConnection.fetch("myEventToDelete") }
     Assert.assertEquals(event.id, eventFromDB?.id)
 
     eventUtils.deleteEvent(event)
-    val eventFromDBAfterDelete = runBlocking { EventFirebaseConnection.fetch("myEventToDelete") }
+    val eventFromDBAfterDelete = runBlocking { eventFirebaseConnection.fetch("myEventToDelete") }
     Assert.assertNull(eventFromDBAfterDelete)
   }
 

--- a/app/src/androidTest/java/com/github/se/gatherspot/screens/EventsScreen.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/screens/EventsScreen.kt
@@ -21,4 +21,5 @@ class EventsScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
       enumValues<Interests>().toList().map { i -> onNode { hasTestTag(i.toString()) } }
   val myEvents: KNode = onNode { hasTestTag("myEvents") }
   val registeredTo: KNode = onNode { hasTestTag("registeredTo") }
+  val eventCreated: KNode = onNode { hasTestTag("Basketball Game") }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/ChatUITest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/ChatUITest.kt
@@ -3,6 +3,7 @@ package com.github.se.gatherspot.ui
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.navigation.compose.rememberNavController
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.se.gatherspot.firebase.EventFirebaseConnection
 import com.github.se.gatherspot.model.Interests
 import com.github.se.gatherspot.model.chat.ChatViewModel
 import com.github.se.gatherspot.model.event.Event
@@ -28,7 +29,7 @@ class ChatUITest {
   @Test
   fun testEverythingExists() {
     val eventId = UUID.randomUUID().toString()
-    val eventFirebaseConnection = com.github.se.gatherspot.firebase.EventFirebaseConnection()
+    val eventFirebaseConnection = EventFirebaseConnection()
     val chatViewModel = ChatViewModel(eventId)
     composeTestRule.setContent {
       val event =
@@ -40,26 +41,28 @@ class ChatUITest {
               eventStartDate =
                   LocalDate.parse(
                       "12/04/2026",
-                      DateTimeFormatter.ofPattern(eventFirebaseConnection.DATE_FORMAT)),
+                      DateTimeFormatter.ofPattern(
+                          com.github.se.gatherspot.firebase.EventFirebaseConnection
+                              .DATE_FORMAT_DISPLAYED)),
               eventEndDate =
                   LocalDate.parse(
                       "12/05/2026",
-                      DateTimeFormatter.ofPattern(eventFirebaseConnection.DATE_FORMAT)),
+                      DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
               timeBeginning =
                   LocalTime.parse(
-                      "10:00", DateTimeFormatter.ofPattern(eventFirebaseConnection.TIME_FORMAT)),
+                      "10:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
               timeEnding =
                   LocalTime.parse(
-                      "12:00", DateTimeFormatter.ofPattern(eventFirebaseConnection.TIME_FORMAT)),
+                      "12:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
               attendanceMaxCapacity = 100,
               attendanceMinCapacity = 10,
               inscriptionLimitDate =
                   LocalDate.parse(
                       "10/04/2025",
-                      DateTimeFormatter.ofPattern(eventFirebaseConnection.DATE_FORMAT)),
+                      DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
               inscriptionLimitTime =
                   LocalTime.parse(
-                      "09:00", DateTimeFormatter.ofPattern(eventFirebaseConnection.TIME_FORMAT)),
+                      "09:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
               eventStatus = EventStatus.CREATED,
               categories = setOf(Interests.CHESS),
               registeredUsers = mutableListOf("my_id"),

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/ChatsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/ChatsTest.kt
@@ -18,6 +18,7 @@ import io.github.kakaocup.compose.node.element.ComposeScreen
 import java.time.LocalDate
 import java.time.LocalTime
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -36,6 +37,7 @@ class ChatsTest {
     Firebase.auth
         .signInWithEmailAndPassword("neverdeleted@mail.com", "GatherSpot,2024;")
         .addOnSuccessListener { id = Firebase.auth.currentUser?.uid ?: "" }
+        .await()
 
     EventFirebaseConnection()
         .add(

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/CreateEventTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/CreateEventTest.kt
@@ -197,6 +197,7 @@ class CreateEventTest {
       alertBox { assertDoesNotExist() }
     }
   }
+
   // Restructured to use EventDataFormScreen
   @Test
   fun testMinimalData() {
@@ -335,6 +336,7 @@ class CreateEventTest {
       alertBox.assertDoesNotExist()
     }
   }
+
   // Does not work
 
   @OptIn(ExperimentalTestApi::class)

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/CreateEventTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/CreateEventTest.kt
@@ -32,7 +32,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class CreateEventTest {
 
-  private val EventFirebaseConnection = EventFirebaseConnection()
+  private val eventFirebaseConnection = EventFirebaseConnection()
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -81,13 +81,13 @@ class CreateEventTest {
         assertExists()
         assert(hasText("Start Date of the event*"))
         performClick()
-        assert(hasText(EventFirebaseConnection.DATE_FORMAT))
+        assert(hasText(EventFirebaseConnection.DATE_FORMAT_DISPLAYED))
       }
       eventEndDate {
         assertExists()
         assert(hasText("End date of the event"))
         performClick()
-        assert(hasText(EventFirebaseConnection.DATE_FORMAT))
+        assert(hasText(EventFirebaseConnection.DATE_FORMAT_DISPLAYED))
       }
       eventTimeStart {
         assertExists()
@@ -126,7 +126,7 @@ class CreateEventTest {
         performScrollTo()
         assert(hasText("Inscription Limit Date"))
         performClick()
-        assert(hasText(EventFirebaseConnection.DATE_FORMAT))
+        assert(hasText(EventFirebaseConnection.DATE_FORMAT_DISPLAYED))
       }
       Espresso.closeSoftKeyboard()
       eventInscriptionLimitTime {
@@ -429,12 +429,12 @@ class CreateEventTest {
       eventStartDate {
         composeTestRule.onNodeWithText("Start Date of the event*").assertIsDisplayed()
         performClick()
-        assert(hasText(EventFirebaseConnection.DATE_FORMAT))
+        assert(hasText(EventFirebaseConnection.DATE_FORMAT_DISPLAYED))
       }
       eventEndDate {
         composeTestRule.onNodeWithText("End date of the event").assertIsDisplayed()
         performClick()
-        assert(hasText(EventFirebaseConnection.DATE_FORMAT))
+        assert(hasText(EventFirebaseConnection.DATE_FORMAT_DISPLAYED))
       }
       eventTimeStart {
         composeTestRule.onNodeWithText("Start time*").assertIsDisplayed()
@@ -465,7 +465,7 @@ class CreateEventTest {
         performScrollTo()
         composeTestRule.onNodeWithText("Inscription Limit Date").assertIsDisplayed()
         performClick()
-        assert(hasText(EventFirebaseConnection.DATE_FORMAT))
+        assert(hasText(EventFirebaseConnection.DATE_FORMAT_DISPLAYED))
       }
       eventInscriptionLimitTime {
         performScrollTo()

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EditEventTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EditEventTest.kt
@@ -23,7 +23,7 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class EditEventTest {
 
-  private val EventFirebaseConnection = EventFirebaseConnection()
+  private val eventFirebaseConnection = EventFirebaseConnection()
   private val testEvent =
       Event(
           id = "testID",
@@ -32,10 +32,12 @@ class EditEventTest {
           location = Location(0.0, 0.0, "Test Location"),
           eventStartDate =
               LocalDate.parse(
-                  "12/04/2026", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                  "12/04/2026",
+                  DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
           eventEndDate =
               LocalDate.parse(
-                  "12/05/2026", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                  "12/05/2026",
+                  DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
           timeBeginning =
               LocalTime.parse(
                   "10:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
@@ -46,7 +48,8 @@ class EditEventTest {
           attendanceMinCapacity = 10,
           inscriptionLimitDate =
               LocalDate.parse(
-                  "10/04/2025", DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                  "10/04/2025",
+                  DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
           inscriptionLimitTime =
               LocalTime.parse(
                   "12:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventQRCodeUITest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventQRCodeUITest.kt
@@ -21,9 +21,8 @@ class EventQRCodeUITest {
   @get:Rule val composeTestRule = createComposeRule()
 
   @Test
-  fun testEveryhtingExists() {
+  fun testEverythingExists() {
     composeTestRule.setContent {
-      val EventFirebaseConnection = EventFirebaseConnection()
       val event =
           Event(
               id = "testID",
@@ -33,11 +32,11 @@ class EventQRCodeUITest {
               eventStartDate =
                   LocalDate.parse(
                       "12/04/2026",
-                      DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                      DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
               eventEndDate =
                   LocalDate.parse(
                       "12/05/2026",
-                      DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                      DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
               timeBeginning =
                   LocalTime.parse(
                       "10:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),
@@ -49,7 +48,7 @@ class EventQRCodeUITest {
               inscriptionLimitDate =
                   LocalDate.parse(
                       "10/04/2025",
-                      DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT)),
+                      DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED)),
               inscriptionLimitTime =
                   LocalTime.parse(
                       "12:00", DateTimeFormatter.ofPattern(EventFirebaseConnection.TIME_FORMAT)),

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventUITest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventUITest.kt
@@ -368,7 +368,7 @@ class EventUITest {
               inscriptionLimitDate = LocalDate.of(2024, 4, 11),
               inscriptionLimitTime = LocalTime.of(23, 59),
               location = null,
-              registeredUsers = mutableListOf("TEST"),
+              registeredUsers = mutableListOf(FirebaseAuth.getInstance().currentUser!!.uid),
               timeBeginning = LocalTime.of(13, 0),
               timeEnding = LocalTime.of(16, 0),
           )
@@ -378,22 +378,11 @@ class EventUITest {
       EventUI(
           event,
           NavigationActions(navController),
-          EventRegistrationViewModel(listOf()),
+          EventRegistrationViewModel(listOf(FirebaseAuth.getInstance().currentUser!!.uid)),
           EventsViewModel())
     }
+    Thread.sleep(3000)
     ComposeScreen.onComposeScreen<EventUIScreen>(composeTestRule) {
-      registerButton {
-        performScrollTo()
-        performClick()
-      }
-      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("alertBox"), 6000)
-      alertBox {
-        assertIsDisplayed()
-        hasText("Already registered for this event")
-      }
-
-      okButton.performClick()
-      Thread.sleep(2000)
       registerButton {
         performScrollTo()
         assertIsNotEnabled()

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -394,10 +394,11 @@ class EventsTest {
         }
       }
     }
-    Thread.sleep(3000)
+
     ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu { performClick() } }
-    Thread.sleep(3000)
+
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
+      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("inputTitle"), 5000)
       eventTitle.performTextInput("Basketball Game")
       Espresso.closeSoftKeyboard()
       eventDescription.performTextInput("Ayo, 5v5: Come show your skills")

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -341,7 +341,7 @@ class EventsTest {
 
     composeTestRule.setContent {
       val navController = rememberNavController()
-      NavHost(navController = navController, startDestination = "createEvent") {
+      NavHost(navController = navController, startDestination = "home") {
         navigation(startDestination = "events", route = "home") {
           composable("events") { Events(viewModel, NavigationActions(navController)) }
         }
@@ -395,6 +395,8 @@ class EventsTest {
       }
     }
 
+    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu.performClick() }
+
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
       composeTestRule.waitUntilAtLeastOneExists(hasTestTag("inputTitle"), 5000)
       eventTitle.performTextInput("Basketball Game")
@@ -427,8 +429,6 @@ class EventsTest {
       eventSaveButton.performClick()
     }
 
-    Thread.sleep(5000)
-    // more asserts are needed but ok for now
     ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
       filterMenu { performClick() }
       myEvents {
@@ -443,12 +443,10 @@ class EventsTest {
       eventCreated { performClick() }
     }
 
-    Thread.sleep(3000)
     ComposeScreen.onComposeScreen<EventUIScreen>(composeTestRule) {
       editEventButton { performClick() }
     }
 
-    Thread.sleep(3000)
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
       eventDescription { assertTextContains("Ayo, 5v5: Come show your skills") }
     }

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -345,10 +345,10 @@ class EventsTest {
             attendanceMinCapacity = 5,
             organizerID = uid,
             categories = setOf(Interests.BASKETBALL),
-            eventEndDate = LocalDate.of(2024, 5, 15),
-            eventStartDate = LocalDate.of(2024, 5, 15),
+            eventEndDate = LocalDate.of(2024, 6, 15),
+            eventStartDate = LocalDate.of(2024, 6, 15),
             globalRating = 4,
-            inscriptionLimitDate = LocalDate.of(2024, 4, 11),
+            inscriptionLimitDate = LocalDate.of(2024, 6, 11),
             inscriptionLimitTime = LocalTime.of(23, 59),
             location = null,
             registeredUsers = mutableListOf(),
@@ -363,6 +363,7 @@ class EventsTest {
 
     val viewModel = EventsViewModel()
     Thread.sleep(5000)
+    assert(viewModel.uiState.value.list.isNotEmpty())
 
     composeTestRule.setContent {
       val navController = rememberNavController()
@@ -420,43 +421,6 @@ class EventsTest {
       }
     }
 
-    /*
-    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu.performClick() }
-
-    ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
-      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("inputTitle"), 5000)
-      eventTitle.performTextInput("Basketball Game")
-      Espresso.closeSoftKeyboard()
-      eventDescription.performTextInput("Ayo, 5v5: Come show your skills")
-      Espresso.closeSoftKeyboard()
-      eventStartDate.performTextInput("10/07/2024")
-      Espresso.closeSoftKeyboard()
-      eventEndDate.performTextInput("10/07/2024")
-      Espresso.closeSoftKeyboard()
-      eventTimeStart.performTextInput("13:00")
-      Espresso.closeSoftKeyboard()
-      eventTimeEnd.performTextInput("19:00")
-      Espresso.closeSoftKeyboard()
-      eventLocation.performTextInput("Bussy-Saint-Georges")
-      Espresso.closeSoftKeyboard()
-      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MenuItem"), 6000)
-      Espresso.closeSoftKeyboard()
-      locationProposition { performClick() }
-      Espresso.closeSoftKeyboard()
-      eventMaxAttendees.performTextInput("10")
-      Espresso.closeSoftKeyboard()
-      eventMinAttendees.performTextInput("5")
-      Espresso.closeSoftKeyboard()
-      eventInscriptionLimitDate.performTextInput("10/06/2024")
-      Espresso.closeSoftKeyboard()
-      eventInscriptionLimitTime.performTextInput("09:00")
-      Espresso.closeSoftKeyboard()
-      eventSaveButton.performScrollTo()
-      eventSaveButton.performClick()
-    }
-
-     */
-
     ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
       composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 6000)
       filterMenu { performClick() }
@@ -484,3 +448,40 @@ class EventsTest {
     EventFirebaseConnection().delete(event.id)
   }
 }
+
+/*
+ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu.performClick() }
+
+ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
+  composeTestRule.waitUntilAtLeastOneExists(hasTestTag("inputTitle"), 5000)
+  eventTitle.performTextInput("Basketball Game")
+  Espresso.closeSoftKeyboard()
+  eventDescription.performTextInput("Ayo, 5v5: Come show your skills")
+  Espresso.closeSoftKeyboard()
+  eventStartDate.performTextInput("10/07/2024")
+  Espresso.closeSoftKeyboard()
+  eventEndDate.performTextInput("10/07/2024")
+  Espresso.closeSoftKeyboard()
+  eventTimeStart.performTextInput("13:00")
+  Espresso.closeSoftKeyboard()
+  eventTimeEnd.performTextInput("19:00")
+  Espresso.closeSoftKeyboard()
+  eventLocation.performTextInput("Bussy-Saint-Georges")
+  Espresso.closeSoftKeyboard()
+  composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MenuItem"), 6000)
+  Espresso.closeSoftKeyboard()
+  locationProposition { performClick() }
+  Espresso.closeSoftKeyboard()
+  eventMaxAttendees.performTextInput("10")
+  Espresso.closeSoftKeyboard()
+  eventMinAttendees.performTextInput("5")
+  Espresso.closeSoftKeyboard()
+  eventInscriptionLimitDate.performTextInput("10/06/2024")
+  Espresso.closeSoftKeyboard()
+  eventInscriptionLimitTime.performTextInput("09:00")
+  Espresso.closeSoftKeyboard()
+  eventSaveButton.performScrollTo()
+  eventSaveButton.performClick()
+}
+
+ */

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -399,7 +399,8 @@ class EventsTest {
     ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu.performClick() }
 
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
-      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("inputTitle"), 5000)
+      composeTestRule.waitForIdle()
+      eventTitle.performScrollTo()
       eventTitle.performTextInput("Basketball Game")
       Espresso.closeSoftKeyboard()
       eventDescription.performTextInput("Ayo, 5v5: Come show your skills")

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -33,6 +33,7 @@ import com.google.gson.GsonBuilder
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import java.time.LocalDate
 import java.time.LocalTime
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -357,6 +358,8 @@ class EventsTest {
 
     val eventFirebase = EventFirebaseConnection()
     eventFirebase.add(eventCreated)
+
+    runBlocking { eventFirebase.fetch(eventCreated.id) }
 
     val viewModel = EventsViewModel()
     Thread.sleep(5000)

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -34,7 +34,6 @@ import com.google.gson.GsonBuilder
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import java.time.LocalDate
 import java.time.LocalTime
-import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -351,9 +350,9 @@ class EventsTest {
         navigation(startDestination = "form", route = "createEvent") {
           composable("form") {
             CreateEvent(
-              nav = NavigationActions(navController),
-              eventUtils = EventUtils(),
-              viewModel = viewModel)
+                nav = NavigationActions(navController),
+                eventUtils = EventUtils(),
+                viewModel = viewModel)
           }
         }
         navigation(startDestination = "view", route = "event/{eventJson}") {
@@ -397,9 +396,7 @@ class EventsTest {
       }
     }
 
-    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule){
-      createMenu.performClick()
-    }
+    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu.performClick() }
 
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
       composeTestRule.waitUntilAtLeastOneExists(hasTestTag("inputTitle"), 5000)

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -32,18 +32,17 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import io.github.kakaocup.compose.node.element.ComposeScreen
+import java.time.LocalDate
+import java.time.LocalTime
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.time.LocalDate
-import java.time.LocalTime
 
 @RunWith(AndroidJUnit4::class)
 class EventsTest {
-  @get:Rule
-  val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
   private lateinit var uid: String
 
   @Before
@@ -166,8 +165,8 @@ class EventsTest {
       for (category in categories) {
         category {
           composeTestRule
-            .onNodeWithTag("dropdown")
-            .performScrollToNode(hasTestTag(enumValues<Interests>().toList()[c].toString()))
+              .onNodeWithTag("dropdown")
+              .performScrollToNode(hasTestTag(enumValues<Interests>().toList()[c].toString()))
           assertExists()
           performClick()
           performClick()
@@ -198,8 +197,8 @@ class EventsTest {
 
       categories[index] {
         composeTestRule
-          .onNodeWithTag("dropdown")
-          .performScrollToNode(hasTestTag(enumValues<Interests>().toList()[index].toString()))
+            .onNodeWithTag("dropdown")
+            .performScrollToNode(hasTestTag(enumValues<Interests>().toList()[index].toString()))
         assertExists()
         performClick()
       }
@@ -209,7 +208,7 @@ class EventsTest {
       composeTestRule.waitForIdle()
       Thread.sleep(3000)
       assert(
-        viewModel.uiState.value.list.all { e -> e.categories?.contains(Interests.SPORT) ?: true })
+          viewModel.uiState.value.list.all { e -> e.categories?.contains(Interests.SPORT) ?: true })
     }
   }
 
@@ -236,20 +235,18 @@ class EventsTest {
 
       categories[indexBasketball] {
         composeTestRule
-          .onNodeWithTag("dropdown")
-          .performScrollToNode(
-            hasTestTag(enumValues<Interests>().toList()[indexBasketball].toString())
-          )
+            .onNodeWithTag("dropdown")
+            .performScrollToNode(
+                hasTestTag(enumValues<Interests>().toList()[indexBasketball].toString()))
         assertExists()
         performClick()
       }
 
       categories[indexChess] {
         composeTestRule
-          .onNodeWithTag("dropdown")
-          .performScrollToNode(
-            hasTestTag(enumValues<Interests>().toList()[indexChess].toString())
-          )
+            .onNodeWithTag("dropdown")
+            .performScrollToNode(
+                hasTestTag(enumValues<Interests>().toList()[indexChess].toString()))
         assertExists()
         performClick()
       }
@@ -266,14 +263,14 @@ class EventsTest {
       Thread.sleep(3000)
 
       assert(
-        viewModel.uiState.value.list.all { e ->
-          if (e.categories == null) {
-            false
-          } else {
-            e.categories!!.contains(Interests.BASKETBALL) ||
-                    e.categories!!.contains(Interests.CHESS)
-          }
-        })
+          viewModel.uiState.value.list.all { e ->
+            if (e.categories == null) {
+              false
+            } else {
+              e.categories!!.contains(Interests.BASKETBALL) ||
+                  e.categories!!.contains(Interests.CHESS)
+            }
+          })
     }
   }
 
@@ -336,7 +333,6 @@ class EventsTest {
     }
   }
 
-
   @OptIn(ExperimentalTestApi::class)
   @Test
   fun entireCreationFlow() {
@@ -352,124 +348,111 @@ class EventsTest {
         navigation(startDestination = "form", route = "createEvent") {
           composable("form") {
             EventDataForm(
-              eventUtils = EventUtils(),
-              viewModel = viewModel,
-              nav = NavigationActions(navController),
-              eventAction = EventAction.CREATE
-            )
+                eventUtils = EventUtils(),
+                viewModel = viewModel,
+                nav = NavigationActions(navController),
+                eventAction = EventAction.CREATE)
           }
         }
         navigation(startDestination = "view", route = "event/{eventJson}") {
           composable("view") { backStackEntry ->
             val gson: Gson =
-              GsonBuilder()
-                .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
-                .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
-                .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
-                .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
-                .create()
+                GsonBuilder()
+                    .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
+                    .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
+                    .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
+                    .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+                    .create()
             val eventObject =
-              gson.fromJson(
-                backStackEntry.arguments?.getString("eventJson"), Event::class.java
-              )
+                gson.fromJson(backStackEntry.arguments?.getString("eventJson"), Event::class.java)
             EventUI(
-              event = eventObject,
-              navActions = NavigationActions(navController),
-              registrationViewModel = EventRegistrationViewModel(eventObject.registeredUsers),
-              eventsViewModel = viewModel
-            )
+                event = eventObject,
+                navActions = NavigationActions(navController),
+                registrationViewModel = EventRegistrationViewModel(eventObject.registeredUsers),
+                eventsViewModel = viewModel)
           }
         }
         navigation(startDestination = "edit", route = "editEvent/{eventJson}") {
           composable("edit") { backStackEntry ->
             val gson: Gson =
-              GsonBuilder()
-                .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
-                .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
-                .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
-                .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
-                .create()
+                GsonBuilder()
+                    .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
+                    .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
+                    .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
+                    .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+                    .create()
 
             val eventObject =
-              gson.fromJson(
-                backStackEntry.arguments?.getString("eventJson"), Event::class.java
-              )
+                gson.fromJson(backStackEntry.arguments?.getString("eventJson"), Event::class.java)
 
             EditEvent(
-              event = eventObject,
-              eventUtils = EventUtils(),
-              nav = NavigationActions(navController),
-              viewModel = viewModel
-            )
+                event = eventObject,
+                eventUtils = EventUtils(),
+                nav = NavigationActions(navController),
+                viewModel = viewModel)
           }
         }
       }
     }
 
-      ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu { performClick() } }
+    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu { performClick() } }
 
-      ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
-        eventTitle.performTextInput("Basketball Game")
-        Espresso.closeSoftKeyboard()
-        eventDescription.performTextInput("Ayo, 5v5: Come show your skills")
-        Espresso.closeSoftKeyboard()
-        eventStartDate.performTextInput("10/07/2024")
-        Espresso.closeSoftKeyboard()
-        eventEndDate.performTextInput("10/07/2024")
-        Espresso.closeSoftKeyboard()
-        eventTimeStart.performTextInput("13:00")
-        Espresso.closeSoftKeyboard()
-        eventTimeEnd.performTextInput("19:00")
-        Espresso.closeSoftKeyboard()
-        eventLocation.performTextInput("Bussy-Saint-Georges")
-        Espresso.closeSoftKeyboard()
-        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MenuItem"), 6000)
-        Espresso.closeSoftKeyboard()
-        locationProposition { performClick() }
-        Espresso.closeSoftKeyboard()
-        eventMaxAttendees.performTextInput("10")
-        Espresso.closeSoftKeyboard()
-        eventMinAttendees.performTextInput("5")
-        Espresso.closeSoftKeyboard()
-        eventInscriptionLimitDate.performTextInput("10/06/2024")
-        Espresso.closeSoftKeyboard()
-        eventInscriptionLimitTime.performTextInput("09:00")
-        Espresso.closeSoftKeyboard()
-        eventSaveButton.performScrollTo()
-        eventSaveButton.performClick()
-      }
-
-      Thread.sleep(5000)
-      // more asserts are needed but ok for now
-      ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
-        filterMenu { performClick() }
-        myEvents {
-          composeTestRule.onNodeWithTag("dropdown").performScrollToNode(hasTestTag("myEvents"))
-          performClick()
-        }
-        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 6000)
-        assert(viewModel.uiState.value.list.any { event -> event.description == "Ayo, 5v5: Come show your skills" })
-        eventCreated {
-          performClick()
-        }
-      }
-
-
-      ComposeScreen.onComposeScreen<EventUIScreen>(composeTestRule) {
-        editEventButton {
-          performClick()
-        }
-      }
-
-      ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
-        eventDescription {
-          assertTextContains("Ayo, 5v5: Come show your skills")
-        }
-      }
-
-      val event = viewModel.uiState.value.list.filter { e -> e.title == "Basketball Game" }[0]
-      EventFirebaseConnection().delete(event.id)
+    ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
+      eventTitle.performTextInput("Basketball Game")
+      Espresso.closeSoftKeyboard()
+      eventDescription.performTextInput("Ayo, 5v5: Come show your skills")
+      Espresso.closeSoftKeyboard()
+      eventStartDate.performTextInput("10/07/2024")
+      Espresso.closeSoftKeyboard()
+      eventEndDate.performTextInput("10/07/2024")
+      Espresso.closeSoftKeyboard()
+      eventTimeStart.performTextInput("13:00")
+      Espresso.closeSoftKeyboard()
+      eventTimeEnd.performTextInput("19:00")
+      Espresso.closeSoftKeyboard()
+      eventLocation.performTextInput("Bussy-Saint-Georges")
+      Espresso.closeSoftKeyboard()
+      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MenuItem"), 6000)
+      Espresso.closeSoftKeyboard()
+      locationProposition { performClick() }
+      Espresso.closeSoftKeyboard()
+      eventMaxAttendees.performTextInput("10")
+      Espresso.closeSoftKeyboard()
+      eventMinAttendees.performTextInput("5")
+      Espresso.closeSoftKeyboard()
+      eventInscriptionLimitDate.performTextInput("10/06/2024")
+      Espresso.closeSoftKeyboard()
+      eventInscriptionLimitTime.performTextInput("09:00")
+      Espresso.closeSoftKeyboard()
+      eventSaveButton.performScrollTo()
+      eventSaveButton.performClick()
     }
 
-}
+    Thread.sleep(5000)
+    // more asserts are needed but ok for now
+    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
+      filterMenu { performClick() }
+      myEvents {
+        composeTestRule.onNodeWithTag("dropdown").performScrollToNode(hasTestTag("myEvents"))
+        performClick()
+      }
+      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 6000)
+      assert(
+          viewModel.uiState.value.list.any { event ->
+            event.description == "Ayo, 5v5: Come show your skills"
+          })
+      eventCreated { performClick() }
+    }
 
+    ComposeScreen.onComposeScreen<EventUIScreen>(composeTestRule) {
+      editEventButton { performClick() }
+    }
+
+    ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
+      eventDescription { assertTextContains("Ayo, 5v5: Come show your skills") }
+    }
+
+    val event = viewModel.uiState.value.list.filter { e -> e.title == "Basketball Game" }[0]
+    EventFirebaseConnection().delete(event.id)
+  }
+}

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -394,9 +394,9 @@ class EventsTest {
         }
       }
     }
-
+    Thread.sleep(3000)
     ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu { performClick() } }
-
+    Thread.sleep(3000)
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
       eventTitle.performTextInput("Basketball Game")
       Espresso.closeSoftKeyboard()
@@ -444,10 +444,12 @@ class EventsTest {
       eventCreated { performClick() }
     }
 
+    Thread.sleep(3000)
     ComposeScreen.onComposeScreen<EventUIScreen>(composeTestRule) {
       editEventButton { performClick() }
     }
 
+    Thread.sleep(3000)
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
       eventDescription { assertTextContains("Ayo, 5v5: Come show your skills") }
     }

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -10,7 +10,6 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
-import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.gatherspot.EnvironmentSetter.Companion.testLogin
 import com.github.se.gatherspot.EnvironmentSetter.Companion.testLoginCleanUp
@@ -336,6 +335,29 @@ class EventsTest {
   @OptIn(ExperimentalTestApi::class)
   @Test
   fun entireCreationFlow() {
+    val eventCreated =
+        Event(
+            id = "8",
+            title = "Basketball Game",
+            description = "Ayo, 5v5: Come show your skills",
+            attendanceMaxCapacity = 10,
+            attendanceMinCapacity = 5,
+            organizerID = uid,
+            categories = setOf(Interests.BASKETBALL),
+            eventEndDate = LocalDate.of(2024, 5, 15),
+            eventStartDate = LocalDate.of(2024, 5, 15),
+            globalRating = 4,
+            inscriptionLimitDate = LocalDate.of(2024, 4, 11),
+            inscriptionLimitTime = LocalTime.of(23, 59),
+            location = null,
+            registeredUsers = mutableListOf(),
+            timeBeginning = LocalTime.of(13, 0),
+            timeEnding = LocalTime.of(19, 0),
+        )
+
+    val eventFirebase = EventFirebaseConnection()
+    eventFirebase.add(eventCreated)
+
     val viewModel = EventsViewModel()
     Thread.sleep(5000)
 
@@ -395,6 +417,7 @@ class EventsTest {
       }
     }
 
+    /*
     ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu.performClick() }
 
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
@@ -428,6 +451,8 @@ class EventsTest {
       eventSaveButton.performScrollTo()
       eventSaveButton.performClick()
     }
+
+     */
 
     ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
       filterMenu { performClick() }

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -6,34 +6,16 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.swipeUp
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navigation
-import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.gatherspot.EnvironmentSetter.Companion.testLogin
 import com.github.se.gatherspot.EnvironmentSetter.Companion.testLoginCleanUp
-import com.github.se.gatherspot.firebase.EventFirebaseConnection
-import com.github.se.gatherspot.model.EventUtils
 import com.github.se.gatherspot.model.EventsViewModel
 import com.github.se.gatherspot.model.Interests
-import com.github.se.gatherspot.model.event.Event
-import com.github.se.gatherspot.model.event.EventRegistrationViewModel
-import com.github.se.gatherspot.model.utils.LocalDateDeserializer
-import com.github.se.gatherspot.model.utils.LocalDateSerializer
-import com.github.se.gatherspot.model.utils.LocalTimeDeserializer
-import com.github.se.gatherspot.model.utils.LocalTimeSerializer
-import com.github.se.gatherspot.screens.EventDataFormScreen
-import com.github.se.gatherspot.screens.EventUIScreen
 import com.github.se.gatherspot.screens.EventsScreen
 import com.github.se.gatherspot.ui.navigation.NavigationActions
 import com.google.firebase.auth.FirebaseAuth
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
 import io.github.kakaocup.compose.node.element.ComposeScreen
-import java.time.LocalDate
-import java.time.LocalTime
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -336,7 +318,7 @@ class EventsTest {
   @OptIn(ExperimentalTestApi::class)
   @Test
   fun entireCreationFlow() {
-
+    /*
     val viewModel = EventsViewModel()
     Thread.sleep(6000)
     assert(viewModel.uiState.value.list.isNotEmpty())
@@ -395,8 +377,10 @@ class EventsTest {
         }
       }
     }
+    composeTestRule.waitForIdle()
 
     ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu.performClick() }
+    composeTestRule.waitForIdle()
 
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
       composeTestRule.waitForIdle()
@@ -454,6 +438,8 @@ class EventsTest {
 
     val event = viewModel.uiState.value.list.filter { e -> e.title == "Basketball Game" }[0]
     EventFirebaseConnection().delete(event.id)
+
+     */
   }
 }
 

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -362,7 +362,7 @@ class EventsTest {
     runBlocking { eventFirebase.fetch(eventCreated.id) }
 
     val viewModel = EventsViewModel()
-    Thread.sleep(5000)
+    Thread.sleep(6000)
     assert(viewModel.uiState.value.list.isNotEmpty())
 
     composeTestRule.setContent {
@@ -422,13 +422,13 @@ class EventsTest {
     }
 
     ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
-      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 6000)
+      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 12000)
       filterMenu { performClick() }
       myEvents {
         composeTestRule.onNodeWithTag("dropdown").performScrollToNode(hasTestTag("myEvents"))
         performClick()
       }
-      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 6000)
+      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 12000)
       assert(
           viewModel.uiState.value.list.any { event ->
             event.description == "Ayo, 5v5: Come show your skills"

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -341,7 +341,7 @@ class EventsTest {
 
     composeTestRule.setContent {
       val navController = rememberNavController()
-      NavHost(navController = navController, startDestination = "home") {
+      NavHost(navController = navController, startDestination = "createEvent") {
         navigation(startDestination = "events", route = "home") {
           composable("events") { Events(viewModel, NavigationActions(navController)) }
         }
@@ -394,8 +394,6 @@ class EventsTest {
         }
       }
     }
-
-    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu { performClick() } }
 
     ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
       composeTestRule.waitUntilAtLeastOneExists(hasTestTag("inputTitle"), 5000)

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -6,25 +6,44 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.swipeUp
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navigation
+import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.se.gatherspot.EnvironmentSetter.Companion.testLogin
 import com.github.se.gatherspot.EnvironmentSetter.Companion.testLoginCleanUp
+import com.github.se.gatherspot.firebase.EventFirebaseConnection
+import com.github.se.gatherspot.model.EventUtils
 import com.github.se.gatherspot.model.EventsViewModel
 import com.github.se.gatherspot.model.Interests
+import com.github.se.gatherspot.model.event.Event
+import com.github.se.gatherspot.model.event.EventRegistrationViewModel
+import com.github.se.gatherspot.model.utils.LocalDateDeserializer
+import com.github.se.gatherspot.model.utils.LocalDateSerializer
+import com.github.se.gatherspot.model.utils.LocalTimeDeserializer
+import com.github.se.gatherspot.model.utils.LocalTimeSerializer
+import com.github.se.gatherspot.screens.EventDataFormScreen
+import com.github.se.gatherspot.screens.EventUIScreen
 import com.github.se.gatherspot.screens.EventsScreen
 import com.github.se.gatherspot.ui.navigation.NavigationActions
 import com.google.firebase.auth.FirebaseAuth
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
 import io.github.kakaocup.compose.node.element.ComposeScreen
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.time.LocalDate
+import java.time.LocalTime
 
 @RunWith(AndroidJUnit4::class)
 class EventsTest {
-  @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule
+  val composeTestRule = createComposeRule()
   private lateinit var uid: String
 
   @Before
@@ -147,8 +166,8 @@ class EventsTest {
       for (category in categories) {
         category {
           composeTestRule
-              .onNodeWithTag("dropdown")
-              .performScrollToNode(hasTestTag(enumValues<Interests>().toList()[c].toString()))
+            .onNodeWithTag("dropdown")
+            .performScrollToNode(hasTestTag(enumValues<Interests>().toList()[c].toString()))
           assertExists()
           performClick()
           performClick()
@@ -179,8 +198,8 @@ class EventsTest {
 
       categories[index] {
         composeTestRule
-            .onNodeWithTag("dropdown")
-            .performScrollToNode(hasTestTag(enumValues<Interests>().toList()[index].toString()))
+          .onNodeWithTag("dropdown")
+          .performScrollToNode(hasTestTag(enumValues<Interests>().toList()[index].toString()))
         assertExists()
         performClick()
       }
@@ -190,7 +209,7 @@ class EventsTest {
       composeTestRule.waitForIdle()
       Thread.sleep(3000)
       assert(
-          viewModel.uiState.value.list.all { e -> e.categories?.contains(Interests.SPORT) ?: true })
+        viewModel.uiState.value.list.all { e -> e.categories?.contains(Interests.SPORT) ?: true })
     }
   }
 
@@ -217,18 +236,20 @@ class EventsTest {
 
       categories[indexBasketball] {
         composeTestRule
-            .onNodeWithTag("dropdown")
-            .performScrollToNode(
-                hasTestTag(enumValues<Interests>().toList()[indexBasketball].toString()))
+          .onNodeWithTag("dropdown")
+          .performScrollToNode(
+            hasTestTag(enumValues<Interests>().toList()[indexBasketball].toString())
+          )
         assertExists()
         performClick()
       }
 
       categories[indexChess] {
         composeTestRule
-            .onNodeWithTag("dropdown")
-            .performScrollToNode(
-                hasTestTag(enumValues<Interests>().toList()[indexChess].toString()))
+          .onNodeWithTag("dropdown")
+          .performScrollToNode(
+            hasTestTag(enumValues<Interests>().toList()[indexChess].toString())
+          )
         assertExists()
         performClick()
       }
@@ -245,14 +266,14 @@ class EventsTest {
       Thread.sleep(3000)
 
       assert(
-          viewModel.uiState.value.list.all { e ->
-            if (e.categories == null) {
-              false
-            } else {
-              e.categories!!.contains(Interests.BASKETBALL) ||
-                  e.categories!!.contains(Interests.CHESS)
-            }
-          })
+        viewModel.uiState.value.list.all { e ->
+          if (e.categories == null) {
+            false
+          } else {
+            e.categories!!.contains(Interests.BASKETBALL) ||
+                    e.categories!!.contains(Interests.CHESS)
+          }
+        })
     }
   }
 
@@ -315,7 +336,7 @@ class EventsTest {
     }
   }
 
-  /*
+
   @OptIn(ExperimentalTestApi::class)
   @Test
   fun entireCreationFlow() {
@@ -331,63 +352,124 @@ class EventsTest {
         navigation(startDestination = "form", route = "createEvent") {
           composable("form") {
             EventDataForm(
-                eventUtils = EventUtils(),
-                viewModel = viewModel,
-                nav = NavigationActions(navController),
-                eventAction = EventAction.CREATE)
+              eventUtils = EventUtils(),
+              viewModel = viewModel,
+              nav = NavigationActions(navController),
+              eventAction = EventAction.CREATE
+            )
+          }
+        }
+        navigation(startDestination = "view", route = "event/{eventJson}") {
+          composable("view") { backStackEntry ->
+            val gson: Gson =
+              GsonBuilder()
+                .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
+                .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
+                .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
+                .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+                .create()
+            val eventObject =
+              gson.fromJson(
+                backStackEntry.arguments?.getString("eventJson"), Event::class.java
+              )
+            EventUI(
+              event = eventObject,
+              navActions = NavigationActions(navController),
+              registrationViewModel = EventRegistrationViewModel(eventObject.registeredUsers),
+              eventsViewModel = viewModel
+            )
+          }
+        }
+        navigation(startDestination = "edit", route = "editEvent/{eventJson}") {
+          composable("edit") { backStackEntry ->
+            val gson: Gson =
+              GsonBuilder()
+                .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
+                .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
+                .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
+                .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+                .create()
+
+            val eventObject =
+              gson.fromJson(
+                backStackEntry.arguments?.getString("eventJson"), Event::class.java
+              )
+
+            EditEvent(
+              event = eventObject,
+              eventUtils = EventUtils(),
+              nav = NavigationActions(navController),
+              viewModel = viewModel
+            )
           }
         }
       }
     }
 
-    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu { performClick() } }
+      ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) { createMenu { performClick() } }
 
-    ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
-      eventTitle.performTextInput("Basketball Game")
-      Espresso.closeSoftKeyboard()
-      eventDescription.performTextInput("Ayo, 5v5: Come show your skills")
-      Espresso.closeSoftKeyboard()
-      eventStartDate.performTextInput("10/07/2024")
-      Espresso.closeSoftKeyboard()
-      eventEndDate.performTextInput("10/07/2024")
-      Espresso.closeSoftKeyboard()
-      eventTimeStart.performTextInput("13:00")
-      Espresso.closeSoftKeyboard()
-      eventTimeEnd.performTextInput("19:00")
-      Espresso.closeSoftKeyboard()
-      eventLocation.performTextInput("Bussy-Saint-Georges")
-      Espresso.closeSoftKeyboard()
-      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MenuItem"), 6000)
-      Espresso.closeSoftKeyboard()
-      locationProposition { performClick() }
-      Espresso.closeSoftKeyboard()
-      eventMaxAttendees.performTextInput("10")
-      Espresso.closeSoftKeyboard()
-      eventMinAttendees.performTextInput("5")
-      Espresso.closeSoftKeyboard()
-      eventInscriptionLimitDate.performTextInput("10/06/2024")
-      Espresso.closeSoftKeyboard()
-      eventInscriptionLimitTime.performTextInput("09:00")
-      Espresso.closeSoftKeyboard()
-      eventSaveButton.performScrollTo()
-      eventSaveButton.performClick()
-    }
-
-    Thread.sleep(5000)
-    // more asserts are needed but ok for now
-    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
-      filterMenu { performClick() }
-      myEvents {
-        composeTestRule.onNodeWithTag("dropdown").performScrollToNode(hasTestTag("myEvents"))
-        performClick()
+      ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
+        eventTitle.performTextInput("Basketball Game")
+        Espresso.closeSoftKeyboard()
+        eventDescription.performTextInput("Ayo, 5v5: Come show your skills")
+        Espresso.closeSoftKeyboard()
+        eventStartDate.performTextInput("10/07/2024")
+        Espresso.closeSoftKeyboard()
+        eventEndDate.performTextInput("10/07/2024")
+        Espresso.closeSoftKeyboard()
+        eventTimeStart.performTextInput("13:00")
+        Espresso.closeSoftKeyboard()
+        eventTimeEnd.performTextInput("19:00")
+        Espresso.closeSoftKeyboard()
+        eventLocation.performTextInput("Bussy-Saint-Georges")
+        Espresso.closeSoftKeyboard()
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("MenuItem"), 6000)
+        Espresso.closeSoftKeyboard()
+        locationProposition { performClick() }
+        Espresso.closeSoftKeyboard()
+        eventMaxAttendees.performTextInput("10")
+        Espresso.closeSoftKeyboard()
+        eventMinAttendees.performTextInput("5")
+        Espresso.closeSoftKeyboard()
+        eventInscriptionLimitDate.performTextInput("10/06/2024")
+        Espresso.closeSoftKeyboard()
+        eventInscriptionLimitTime.performTextInput("09:00")
+        Espresso.closeSoftKeyboard()
+        eventSaveButton.performScrollTo()
+        eventSaveButton.performClick()
       }
-      // composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 6000)
-      //  assert(viewModel.uiState.value.list.any { event -> event.description ==  "Ayo, 5v5: Come
-      // show your skills"})
+
+      Thread.sleep(5000)
+      // more asserts are needed but ok for now
+      ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
+        filterMenu { performClick() }
+        myEvents {
+          composeTestRule.onNodeWithTag("dropdown").performScrollToNode(hasTestTag("myEvents"))
+          performClick()
+        }
+        composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 6000)
+        assert(viewModel.uiState.value.list.any { event -> event.description == "Ayo, 5v5: Come show your skills" })
+        eventCreated {
+          performClick()
+        }
+      }
+
+
+      ComposeScreen.onComposeScreen<EventUIScreen>(composeTestRule) {
+        editEventButton {
+          performClick()
+        }
+      }
+
+      ComposeScreen.onComposeScreen<EventDataFormScreen>(composeTestRule) {
+        eventDescription {
+          assertTextContains("Ayo, 5v5: Come show your skills")
+        }
+      }
+
+      val event = viewModel.uiState.value.list.filter { e -> e.title == "Basketball Game" }[0]
+      EventFirebaseConnection().delete(event.id)
     }
 
-    //  EventFirebaseConnection().delete(viewModel.uiState.value.list[0].id)
-  }
-
-   */
 }
+

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -458,6 +458,7 @@ class EventsTest {
      */
 
     ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
+      composeTestRule.waitUntilAtLeastOneExists(hasTestTag("eventsList"), 6000)
       filterMenu { performClick() }
       myEvents {
         composeTestRule.onNodeWithTag("dropdown").performScrollToNode(hasTestTag("myEvents"))

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/profileTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/profileTest.kt
@@ -19,6 +19,7 @@ import org.junit.runner.RunWith
 class ProfileInstrumentedTest {
 
   @get:Rule val composeTestRule = createComposeRule()
+
   // for useful documentation on testing compose
   // https://developer.android.com/develop/ui/compose/testing-cheatsheet
   @Before

--- a/app/src/androidTest/java/com/github/se/gatherspot/utils/JsonCustomsSerializerTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/utils/JsonCustomsSerializerTest.kt
@@ -5,11 +5,12 @@ import androidx.compose.ui.graphics.ImageBitmap
 import com.github.se.gatherspot.model.utils.ImageBitmapSerializer
 import com.github.se.gatherspot.model.utils.LocalDateDeserializer
 import com.github.se.gatherspot.model.utils.LocalDateSerializer
-import com.github.se.gatherspot.model.utils.LocalDateTimeDeserializer
-import com.github.se.gatherspot.model.utils.LocalDateTimeSerializer
+import com.github.se.gatherspot.model.utils.LocalTimeDeserializer
+import com.github.se.gatherspot.model.utils.LocalTimeSerializer
 import com.google.gson.JsonPrimitive
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -32,19 +33,19 @@ class JsonCustomsSerializerTest {
   }
 
   @Test
-  fun testLocalDateTimeSerializer() {
-    val localDateTime = LocalDateTime.of(2022, 12, 31, 23, 59)
-    val serializer = LocalDateTimeSerializer()
-    val jsonElement = serializer.serialize(localDateTime, localDateTime::class.java, null)
-    assertEquals(JsonPrimitive("2022-12-31T23:59:00"), jsonElement)
+  fun testLocalTimeSerializer() {
+    val localTime = LocalTime.of(10, 15)
+    val serializer = LocalTimeSerializer()
+    val jsonElement = serializer.serialize(localTime, LocalTime::class.java, null)
+    assertEquals(JsonPrimitive("10:15:00"), jsonElement)
   }
 
   @Test
-  fun testLocalDateTimeDeserializer() {
-    val jsonElement = JsonPrimitive("2022-12-31T23:59:00")
-    val deserializer = LocalDateTimeDeserializer()
-    val localDateTime = deserializer.deserialize(jsonElement, LocalDateTime::class.java, null)
-    assertEquals(LocalDateTime.of(2022, 12, 31, 23, 59), localDateTime)
+  fun testLocalTimeDeserializer() {
+    val jsonElement = JsonPrimitive("10:15")
+    val deserializer = LocalTimeDeserializer()
+    val localTime = deserializer.deserialize(jsonElement, LocalDateTime::class.java, null)
+    assertEquals(LocalTime.of(10, 15), localTime)
   }
 
   @Test

--- a/app/src/main/java/com/github/se/gatherspot/MainActivity.kt
+++ b/app/src/main/java/com/github/se/gatherspot/MainActivity.kt
@@ -25,8 +25,8 @@ import com.github.se.gatherspot.model.event.Event
 import com.github.se.gatherspot.model.event.EventRegistrationViewModel
 import com.github.se.gatherspot.model.utils.LocalDateDeserializer
 import com.github.se.gatherspot.model.utils.LocalDateSerializer
-import com.github.se.gatherspot.model.utils.LocalDateTimeDeserializer
-import com.github.se.gatherspot.model.utils.LocalDateTimeSerializer
+import com.github.se.gatherspot.model.utils.LocalTimeDeserializer
+import com.github.se.gatherspot.model.utils.LocalTimeSerializer
 import com.github.se.gatherspot.ui.ChatUI
 import com.github.se.gatherspot.ui.Chats
 import com.github.se.gatherspot.ui.Community
@@ -46,7 +46,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.LocalTime
 
 class MainActivity : ComponentActivity() {
   companion object {
@@ -54,11 +54,11 @@ class MainActivity : ComponentActivity() {
   }
 
   private lateinit var navController: NavHostController
+  private var eventsViewModel: EventsViewModel? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
 
     super.onCreate(savedInstanceState)
-    val eventsViewModel = EventsViewModel()
     // val chatViewModel = ChatViewModel()
 
     signInLauncher =
@@ -81,15 +81,20 @@ class MainActivity : ComponentActivity() {
             }
 
             navigation(startDestination = "events", route = "home") {
-              composable("events") { Events(eventsViewModel, NavigationActions(navController)) }
+              composable("events") {
+                if (eventsViewModel == null) {
+                  eventsViewModel = EventsViewModel()
+                }
+                Events(viewModel = eventsViewModel!!, nav = NavigationActions(navController))
+              }
               composable("event/{eventJson}") { backStackEntry ->
                 // Create a new Gson instance with the custom serializers and deserializers
                 val gson: Gson =
                     GsonBuilder()
                         .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
                         .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
-                        .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeSerializer())
-                        .registerTypeAdapter(LocalDateTime::class.java, LocalDateTimeDeserializer())
+                        .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
+                        .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
                         .create()
                 val eventObject =
                     gson.fromJson(
@@ -98,10 +103,17 @@ class MainActivity : ComponentActivity() {
                     event = eventObject!!,
                     navActions = NavigationActions(navController),
                     registrationViewModel = EventRegistrationViewModel(eventObject.registeredUsers),
-                    eventsViewModel = eventsViewModel)
+                    eventsViewModel = eventsViewModel!!)
               }
               composable("editEvent/{eventJson}") { backStackEntry ->
-                val gson = Gson()
+                val gson: Gson =
+                    GsonBuilder()
+                        .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
+                        .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
+                        .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
+                        .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+                        .create()
+
                 val eventObject =
                     gson.fromJson(
                         backStackEntry.arguments?.getString("eventJson"), Event::class.java)
@@ -109,7 +121,7 @@ class MainActivity : ComponentActivity() {
                     event = eventObject!!,
                     eventUtils = EventUtils(),
                     nav = NavigationActions(navController),
-                    viewModel = eventsViewModel)
+                    viewModel = eventsViewModel!!)
               }
 
               composable("map") { Map(NavigationActions(navController)) }
@@ -137,7 +149,7 @@ class MainActivity : ComponentActivity() {
                 CreateEvent(
                     nav = NavigationActions(navController),
                     eventUtils = EventUtils(),
-                    eventsViewModel)
+                    eventsViewModel!!)
               }
 
               composable("setup") {

--- a/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
@@ -243,7 +243,8 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
         Firebase.firestore
             .collection(EVENTS)
             .orderBy("eventID")
-            .whereEqualTo("organizerID", FirebaseAuth.getInstance().currentUser?.uid ?: "forTests")
+            .whereEqualTo(
+                "organizerID", FirebaseAuth.getInstance().currentUser?.uid ?: "noneForTests")
             .get()
             .await()
 
@@ -256,7 +257,7 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
             .collection(EVENTS)
             .orderBy("eventID")
             .whereArrayContains(
-                "registeredUsers", FirebaseAuth.getInstance().currentUser?.uid ?: "forTests")
+                "registeredUsers", FirebaseAuth.getInstance().currentUser?.uid ?: "noneForTests")
             .get()
             .await()
 

--- a/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
@@ -24,9 +24,15 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
   override val COLLECTION = FirebaseCollection.EVENTS.toString().lowercase()
   override val TAG = "FirebaseConnection" // Used for debugging/logs
   val EVENTS = "events" // Collection name for events
-  val DATE_FORMAT = "dd/MM/yyyy"
-  val TIME_FORMAT = "HH:mm"
+
+  companion object {
+    val DATE_FORMAT_DISPLAYED = "dd/MM/yyyy"
+    val DATE_FORMAT_STORED = "yyyy/MM/dd"
+    val TIME_FORMAT = "HH:mm"
+  }
+
   var offset: DocumentSnapshot? = null
+  // val currentDate = LocalDate.now().format(DateTimeFormatter.ofPattern())
 
   /**
    * Maps a document to an Event object
@@ -139,17 +145,23 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
         if (offset == null) {
           Firebase.firestore
               .collection(EVENTS)
+              .orderBy("eventStartDate")
               .orderBy("eventID")
-              // .whereNotEqualTo("eventID",FirebaseAuth.getInstance().currentUser!!.uid)
+              .whereGreaterThan(
+                  "eventStartDate",
+                  LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)))
               .limit(number)
               .get()
               .await()
         } else {
           Firebase.firestore
               .collection(EVENTS)
+              .orderBy("eventStartDate")
               .orderBy("eventID")
-              //  .whereNotEqualTo("eventID", FirebaseAuth.getInstance().currentUser!!.uid)
-              .startAfter(offset!!.get("eventID"))
+              .whereGreaterThan(
+                  "eventStartDate",
+                  LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)))
+              .startAfter(offset!!.get("eventStartDate"), offset!!.get("eventID"))
               .limit(number)
               .get()
               .await()
@@ -197,8 +209,11 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
         if (offset == null) {
           Firebase.firestore
               .collection(EVENTS)
+              .orderBy("eventStartDate")
               .orderBy("eventID")
-              .whereNotEqualTo("organizerID", FirebaseAuth.getInstance().currentUser!!.uid)
+              .whereGreaterThan(
+                  "eventStartDate",
+                  LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)))
               .whereArrayContainsAny("categories", l.map { it.name })
               .limit(number)
               .get()
@@ -206,10 +221,13 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
         } else {
           Firebase.firestore
               .collection(EVENTS)
+              .orderBy("eventStartDate")
               .orderBy("eventID")
-              .whereNotEqualTo("organizerID", FirebaseAuth.getInstance().currentUser!!.uid)
               .whereArrayContainsAny("categories", l.map { it.name })
-              .startAfter(offset!!.get("eventID"))
+              .whereGreaterThan(
+                  "eventStartDate",
+                  LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)))
+              .startAfter(offset!!.get("eventStartDate"), offset!!.get("eventID"))
               .limit(number)
               .get()
               .await()
@@ -220,8 +238,6 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
     return eventsFromQuerySnapshot(querySnapshot)
   }
 
-  // needs change cause events are not yet created with appropriate profile
-  // eventID-> organizerID
   suspend fun fetchMyEvents(): MutableList<Event> {
     val querySnapshot: QuerySnapshot =
         Firebase.firestore
@@ -240,7 +256,7 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
             .collection(EVENTS)
             .orderBy("eventID")
             .whereArrayContains(
-                "registeredUsers", FirebaseAuth.getInstance().currentUser?.uid ?: "forTest")
+                "registeredUsers", FirebaseAuth.getInstance().currentUser?.uid ?: "forTests")
             .get()
             .await()
 
@@ -284,9 +300,13 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
       "null" -> null
       else ->
           try {
-            LocalDate.parse(dateString, DateTimeFormatter.ofPattern(DATE_FORMAT))
+            LocalDate.parse(dateString, DateTimeFormatter.ofPattern(DATE_FORMAT_DISPLAYED))
           } catch (e: Exception) {
-            null
+            try {
+              LocalDate.parse(dateString, DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
+            } catch (e: Exception) {
+              null
+            }
           }
     }
   }
@@ -320,12 +340,15 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
             "eventStartDate" to
                 when (element.eventStartDate) {
                   null -> "null"
-                  else -> element.eventStartDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT))
+                  else ->
+                      element.eventStartDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
                 },
             "eventEndDate" to
                 when (element.eventEndDate) {
                   null -> "null"
-                  else -> element.eventEndDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT))
+                  else ->
+                      element.eventEndDate.format(
+                          DateTimeFormatter.ofPattern(DATE_FORMAT_DISPLAYED))
                 },
             "timeBeginning" to
                 when (element.timeBeginning) {
@@ -347,7 +370,8 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
                 when (element.inscriptionLimitDate) {
                   null -> "null"
                   else ->
-                      element.inscriptionLimitDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT))
+                      element.inscriptionLimitDate.format(
+                          DateTimeFormatter.ofPattern(DATE_FORMAT_DISPLAYED))
                 },
             "inscriptionLimitTime" to
                 when (element.inscriptionLimitTime) {

--- a/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
@@ -32,6 +32,7 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
   }
 
   var offset: DocumentSnapshot? = null
+
   // val currentDate = LocalDate.now().format(DateTimeFormatter.ofPattern())
 
   /**

--- a/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
@@ -116,7 +116,6 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
         finalAttendees = finalAttendee,
         images = images,
         globalRating = globalRating,
-        // TODO: Add organizer
         organizerID = organizerID)
   }
 
@@ -147,7 +146,7 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
               .collection(EVENTS)
               .orderBy("eventStartDate")
               .orderBy("eventID")
-              .whereGreaterThan(
+              .whereGreaterThanOrEqualTo(
                   "eventStartDate",
                   LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)))
               .limit(number)
@@ -158,7 +157,7 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
               .collection(EVENTS)
               .orderBy("eventStartDate")
               .orderBy("eventID")
-              .whereGreaterThan(
+              .whereGreaterThanOrEqualTo(
                   "eventStartDate",
                   LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)))
               .startAfter(offset!!.get("eventStartDate"), offset!!.get("eventID"))
@@ -211,7 +210,7 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
               .collection(EVENTS)
               .orderBy("eventStartDate")
               .orderBy("eventID")
-              .whereGreaterThan(
+              .whereGreaterThanOrEqualTo(
                   "eventStartDate",
                   LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)))
               .whereArrayContainsAny("categories", l.map { it.name })
@@ -224,7 +223,7 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
               .orderBy("eventStartDate")
               .orderBy("eventID")
               .whereArrayContainsAny("categories", l.map { it.name })
-              .whereGreaterThan(
+              .whereGreaterThanOrEqualTo(
                   "eventStartDate",
                   LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)))
               .startAfter(offset!!.get("eventStartDate"), offset!!.get("eventID"))

--- a/app/src/main/java/com/github/se/gatherspot/firebase/IdListFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/IdListFirebaseConnection.kt
@@ -268,6 +268,7 @@ class IdListFirebaseConnection {
         .addOnFailureListener { e -> Log.d(TAG, getErrorMsg, e) }
     return data
   }
+
   // TODO : keep an eye on this function as it might create problems in the future
   /**
    * Deletes a list

--- a/app/src/main/java/com/github/se/gatherspot/firebase/ProfileFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/ProfileFirebaseConnection.kt
@@ -84,8 +84,10 @@ class ProfileFirebaseConnection : FirebaseConnectionInterface<Profile> {
             .whereEqualTo("userName", userName)
             .get()
             .addOnSuccessListener { querysnps ->
-              val res = getFromDocument(querysnps.documents[0])
-              continuation.resume(res)
+              when {
+                querysnps.documents.isEmpty() -> continuation.resume(null)
+                else -> continuation.resume(getFromDocument(querysnps.documents[0]))
+              }
             }
             .addOnFailureListener { exception ->
               Log.d(TAG, exception.toString())

--- a/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
@@ -43,7 +43,7 @@ class EventUtils {
    * @param timeLimitInscription: The last time to register for the event
    * @return The event created
    */
-  private val EventFirebaseConnection = EventFirebaseConnection()
+  private val eventFirebaseConnection = EventFirebaseConnection()
 
   private fun createEvent(
       title: String,
@@ -61,7 +61,7 @@ class EventUtils {
   ): Event {
 
     // First fetch an unique ID for the event
-    val eventID = EventFirebaseConnection.getNewID()
+    val eventID = eventFirebaseConnection.getNewID()
 
     // Create the event
     val event =
@@ -83,7 +83,7 @@ class EventUtils {
             eventStatus = EventStatus.CREATED)
 
     // Add the event to the database
-    EventFirebaseConnection.add(event)
+    eventFirebaseConnection.add(event)
 
     return event
   }
@@ -106,7 +106,7 @@ class EventUtils {
         }
       }
     }
-    EventFirebaseConnection.delete(event.id)
+    eventFirebaseConnection.delete(event.id)
   }
 
   /**
@@ -206,7 +206,8 @@ class EventUtils {
           validateDate(dateLimitInscription, "Invalid inscription limit date format")
       try {
         LocalDate.parse(
-            dateLimitInscription, DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT))
+            dateLimitInscription,
+            DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED))
       } catch (e: Exception) {
         throw Exception("Invalid inscription limit date format")
       }
@@ -294,13 +295,14 @@ class EventUtils {
             eventStatus = EventStatus.CREATED,
         )
     // Add the event to the database
-    EventFirebaseConnection.add(event)
+    eventFirebaseConnection.add(event)
     return event
   }
 
   fun validateDate(date: String, eMessage: String): LocalDate {
     try {
-      return LocalDate.parse(date, DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT))
+      return LocalDate.parse(
+          date, DateTimeFormatter.ofPattern(EventFirebaseConnection.DATE_FORMAT_DISPLAYED))
     } catch (e: Exception) {
       throw Exception(eMessage)
     }

--- a/app/src/main/java/com/github/se/gatherspot/model/FollowList.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/FollowList.kt
@@ -14,6 +14,7 @@ public class FollowList {
     suspend fun followers(uid: String): IdList {
       return IdListFirebaseConnection().fetch(uid, FirebaseCollection.FOLLOWERS) {}
     }
+
     /**
      * Get the list of users that a user is following
      *
@@ -33,6 +34,7 @@ public class FollowList {
     fun isFollowing(uid: String, targetUID: String): MutableLiveData<Boolean> {
       return IdListFirebaseConnection().exists(uid, FirebaseCollection.FOLLOWING, targetUID) {}
     }
+
     /**
      * Make user follow target
      *
@@ -48,6 +50,7 @@ public class FollowList {
           FirebaseCollection.FOLLOWERS,
           uid) {}
     }
+
     /**
      * Make user unfollow target
      *

--- a/app/src/main/java/com/github/se/gatherspot/model/event/Event.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/event/Event.kt
@@ -5,7 +5,15 @@ import androidx.compose.ui.graphics.ImageBitmapConfig
 import com.github.se.gatherspot.firebase.CollectionClass
 import com.github.se.gatherspot.model.Interests
 import com.github.se.gatherspot.model.location.Location
+import com.github.se.gatherspot.model.utils.LocalDateDeserializer
+import com.github.se.gatherspot.model.utils.LocalDateSerializer
+import com.github.se.gatherspot.model.utils.LocalTimeDeserializer
+import com.github.se.gatherspot.model.utils.LocalTimeSerializer
 import com.google.firebase.auth.FirebaseAuth
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -55,4 +63,18 @@ data class Event(
     var images: ImageBitmap? =
         ImageBitmap(30, 30, config = ImageBitmapConfig.Rgb565), // TODO find default image
     val globalRating: Int?,
-) : CollectionClass()
+) : CollectionClass() {
+
+    fun toJson(): String {
+        val gson: Gson =
+            GsonBuilder()
+                .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
+                .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
+                .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
+                .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+                .create()
+        val eventJson = gson.toJson(this)
+        return URLEncoder.encode(eventJson, StandardCharsets.US_ASCII.toString())
+            .replace("+", "%20")
+    }
+}

--- a/app/src/main/java/com/github/se/gatherspot/model/event/Event.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/event/Event.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.ImageBitmapConfig
 import com.github.se.gatherspot.firebase.CollectionClass
 import com.github.se.gatherspot.model.Interests
 import com.github.se.gatherspot.model.location.Location
+import com.github.se.gatherspot.model.utils.ImageBitmapSerializer
 import com.github.se.gatherspot.model.utils.LocalDateDeserializer
 import com.github.se.gatherspot.model.utils.LocalDateSerializer
 import com.github.se.gatherspot.model.utils.LocalTimeDeserializer
@@ -72,6 +73,7 @@ data class Event(
             .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
             .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
             .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+            .registerTypeAdapter(ImageBitmap::class.java, ImageBitmapSerializer())
             .create()
     val eventJson = gson.toJson(this)
     return URLEncoder.encode(eventJson, StandardCharsets.US_ASCII.toString()).replace("+", "%20")

--- a/app/src/main/java/com/github/se/gatherspot/model/event/Event.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/event/Event.kt
@@ -65,16 +65,15 @@ data class Event(
     val globalRating: Int?,
 ) : CollectionClass() {
 
-    fun toJson(): String {
-        val gson: Gson =
-            GsonBuilder()
-                .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
-                .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
-                .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
-                .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
-                .create()
-        val eventJson = gson.toJson(this)
-        return URLEncoder.encode(eventJson, StandardCharsets.US_ASCII.toString())
-            .replace("+", "%20")
-    }
+  fun toJson(): String {
+    val gson: Gson =
+        GsonBuilder()
+            .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
+            .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
+            .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
+            .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+            .create()
+    val eventJson = gson.toJson(this)
+    return URLEncoder.encode(eventJson, StandardCharsets.US_ASCII.toString()).replace("+", "%20")
+  }
 }

--- a/app/src/main/java/com/github/se/gatherspot/model/event/EventRegistrationViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/event/EventRegistrationViewModel.kt
@@ -38,7 +38,8 @@ class EventRegistrationViewModel(registered: List<String>) : ViewModel() {
   val displayAlertDeletion: LiveData<Boolean> = _displayAlertDeletion
 
   // Profile of the user, is needed to add the event to the user's registered events
-  private var registeredEventsList: IdList = IdList.empty(userId, FirebaseCollection.REGISTERED_EVENTS)
+  private var registeredEventsList: IdList =
+      IdList.empty(userId, FirebaseCollection.REGISTERED_EVENTS)
 
   init {
     viewModelScope.launch {

--- a/app/src/main/java/com/github/se/gatherspot/model/event/EventRegistrationViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/event/EventRegistrationViewModel.kt
@@ -38,7 +38,7 @@ class EventRegistrationViewModel(registered: List<String>) : ViewModel() {
   val displayAlertDeletion: LiveData<Boolean> = _displayAlertDeletion
 
   // Profile of the user, is needed to add the event to the user's registered events
-  private var registeredEventsList: IdList? = null
+  private var registeredEventsList: IdList = IdList.empty(userId, FirebaseCollection.REGISTERED_EVENTS)
 
   init {
     viewModelScope.launch {

--- a/app/src/main/java/com/github/se/gatherspot/model/utils/JsonCustomsSerializer.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/utils/JsonCustomsSerializer.kt
@@ -15,7 +15,7 @@ import com.google.gson.JsonSerializer
 import java.io.ByteArrayOutputStream
 import java.lang.reflect.Type
 import java.time.LocalDate
-import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.Base64
 
@@ -43,25 +43,25 @@ class LocalDateDeserializer : JsonDeserializer<LocalDate> {
 }
 
 // Custom serializer for LocalDateTime
-class LocalDateTimeSerializer : JsonSerializer<LocalDateTime> {
+class LocalTimeSerializer : JsonSerializer<LocalTime> {
   override fun serialize(
-      src: LocalDateTime,
+      src: LocalTime,
       typeOfSrc: Type,
       context: JsonSerializationContext?
   ): JsonElement {
-    return JsonPrimitive(src.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+    return JsonPrimitive(src.format(DateTimeFormatter.ISO_LOCAL_TIME))
   }
 }
 
 // Custom deserializer for LocalDateTime
-class LocalDateTimeDeserializer : JsonDeserializer<LocalDateTime> {
+class LocalTimeDeserializer : JsonDeserializer<LocalTime> {
   @Throws(JsonParseException::class)
   override fun deserialize(
       json: JsonElement,
       typeOfT: Type,
       context: JsonDeserializationContext?
-  ): LocalDateTime {
-    return LocalDateTime.parse(json.asString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+  ): LocalTime {
+    return LocalTime.parse(json.asString, DateTimeFormatter.ISO_LOCAL_TIME)
   }
 }
 

--- a/app/src/main/java/com/github/se/gatherspot/ui/EventView.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/EventView.kt
@@ -53,17 +53,9 @@ import com.github.se.gatherspot.model.event.Event
 import com.github.se.gatherspot.model.event.EventRegistrationViewModel
 import com.github.se.gatherspot.model.event.RegistrationState
 import com.github.se.gatherspot.model.location.Location
-import com.github.se.gatherspot.model.utils.LocalDateDeserializer
-import com.github.se.gatherspot.model.utils.LocalDateSerializer
-import com.github.se.gatherspot.model.utils.LocalTimeDeserializer
-import com.github.se.gatherspot.model.utils.LocalTimeSerializer
 import com.github.se.gatherspot.ui.navigation.NavigationActions
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter

--- a/app/src/main/java/com/github/se/gatherspot/ui/EventView.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/EventView.kt
@@ -114,17 +114,7 @@ fun EventUI(
                 // Edit button
                 IconButton(
                     onClick = {
-                      val gson: Gson =
-                          GsonBuilder()
-                              .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
-                              .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
-                              .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
-                              .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
-                              .create()
-                      val eventJson = gson.toJson(event)
-                      val eventJsonWellFormed =
-                          URLEncoder.encode(eventJson, StandardCharsets.US_ASCII.toString())
-                              .replace("+", "%20")
+                      val eventJsonWellFormed = event.toJson()
                       navActions.controller.navigate("editEvent/$eventJsonWellFormed")
                     },
                     modifier = Modifier.testTag("editEventButton")) {

--- a/app/src/main/java/com/github/se/gatherspot/ui/EventView.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/EventView.kt
@@ -53,10 +53,17 @@ import com.github.se.gatherspot.model.event.Event
 import com.github.se.gatherspot.model.event.EventRegistrationViewModel
 import com.github.se.gatherspot.model.event.RegistrationState
 import com.github.se.gatherspot.model.location.Location
+import com.github.se.gatherspot.model.utils.LocalDateDeserializer
+import com.github.se.gatherspot.model.utils.LocalDateSerializer
+import com.github.se.gatherspot.model.utils.LocalTimeDeserializer
+import com.github.se.gatherspot.model.utils.LocalTimeSerializer
 import com.github.se.gatherspot.ui.navigation.NavigationActions
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
@@ -107,9 +114,18 @@ fun EventUI(
                 // Edit button
                 IconButton(
                     onClick = {
-                      val gson = Gson()
+                      val gson: Gson =
+                          GsonBuilder()
+                              .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
+                              .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
+                              .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
+                              .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
+                              .create()
                       val eventJson = gson.toJson(event)
-                      navActions.controller.navigate("event/$eventJson")
+                      val eventJsonWellFormed =
+                          URLEncoder.encode(eventJson, StandardCharsets.US_ASCII.toString())
+                              .replace("+", "%20")
+                      navActions.controller.navigate("editEvent/$eventJsonWellFormed")
                     },
                     modifier = Modifier.testTag("editEventButton")) {
                       Icon(

--- a/app/src/main/java/com/github/se/gatherspot/ui/EventView.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/EventView.kt
@@ -40,10 +40,8 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.compose.rememberNavController
 import com.github.se.gatherspot.R
 import com.github.se.gatherspot.model.EventUtils
 import com.github.se.gatherspot.model.EventsViewModel
@@ -52,12 +50,9 @@ import com.github.se.gatherspot.model.Profile
 import com.github.se.gatherspot.model.event.Event
 import com.github.se.gatherspot.model.event.EventRegistrationViewModel
 import com.github.se.gatherspot.model.event.RegistrationState
-import com.github.se.gatherspot.model.location.Location
 import com.github.se.gatherspot.ui.navigation.NavigationActions
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
-import java.time.LocalDate
-import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
@@ -366,6 +361,7 @@ fun ProfileIndicator(profile: Profile) {
       }
 }
 
+/*
 // Preview for the Event UI, for testing purposes
 @Preview
 @Composable
@@ -398,3 +394,5 @@ fun EventUIPreview() {
       registrationViewModel = viewModel,
       eventsViewModel = EventsViewModel())
 }
+
+ */

--- a/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
@@ -267,25 +267,13 @@ fun EventRow(event: Event, navigation: NavigationActions) {
                         Color.White
                       },
                   shape = RoundedCornerShape(5.dp))
+              .clickable {
+                  val eventJsonWellFormed = event.toJson()
+                  navigation.controller.navigate("event/$eventJsonWellFormed") }
+              .testTag(event.title)
               .fillMaxSize()) {
         Row(
-            modifier =
-                Modifier.fillMaxWidth().padding(vertical = 16.dp, horizontal = 10.dp).clickable {
-                  // Create a new Gson instance with the custom serializers and deserializers
-                  val gson: Gson =
-                      GsonBuilder()
-                          .registerTypeAdapter(LocalDate::class.java, LocalDateSerializer())
-                          .registerTypeAdapter(LocalDate::class.java, LocalDateDeserializer())
-                          .registerTypeAdapter(LocalTime::class.java, LocalTimeSerializer())
-                          .registerTypeAdapter(LocalTime::class.java, LocalTimeDeserializer())
-                          .create()
-
-                  val eventJson = gson.toJson(event)
-                  val eventJsonWellFormed =
-                      URLEncoder.encode(eventJson, StandardCharsets.US_ASCII.toString())
-                          .replace("+", "%20")
-                  navigation.controller.navigate("event/$eventJsonWellFormed")
-                },
+            modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp, horizontal = 10.dp),
             verticalAlignment = Alignment.CenterVertically) {
               Column(modifier = Modifier.weight(1f)) {
                 Image(

--- a/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
@@ -237,7 +237,7 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
 
 @Composable
 fun EventRow(event: Event, navigation: NavigationActions) {
-  val uid = FirebaseAuth.getInstance().currentUser!!.uid
+  val uid = FirebaseAuth.getInstance().currentUser?.uid ?: "noneForTests"
   val isPastEvent = event.eventStartDate!!.isBefore(LocalDate.now())
   val isToday = event.eventStartDate.isEqual(LocalDate.now())
   val isOrganizer = event.organizerID == uid

--- a/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
@@ -55,20 +55,11 @@ import com.github.se.gatherspot.firebase.EventFirebaseConnection
 import com.github.se.gatherspot.model.EventsViewModel
 import com.github.se.gatherspot.model.Interests
 import com.github.se.gatherspot.model.event.Event
-import com.github.se.gatherspot.model.utils.LocalDateDeserializer
-import com.github.se.gatherspot.model.utils.LocalDateSerializer
-import com.github.se.gatherspot.model.utils.LocalTimeDeserializer
-import com.github.se.gatherspot.model.utils.LocalTimeSerializer
 import com.github.se.gatherspot.ui.navigation.BottomNavigationMenu
 import com.github.se.gatherspot.ui.navigation.NavigationActions
 import com.github.se.gatherspot.ui.navigation.TOP_LEVEL_DESTINATIONS
 import com.google.firebase.auth.FirebaseAuth
-import com.google.gson.Gson
-import com.google.gson.GsonBuilder
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 import java.time.LocalDate
-import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.delay
 
@@ -268,8 +259,9 @@ fun EventRow(event: Event, navigation: NavigationActions) {
                       },
                   shape = RoundedCornerShape(5.dp))
               .clickable {
-                  val eventJsonWellFormed = event.toJson()
-                  navigation.controller.navigate("event/$eventJsonWellFormed") }
+                val eventJsonWellFormed = event.toJson()
+                navigation.controller.navigate("event/$eventJsonWellFormed")
+              }
               .testTag(event.title)
               .fillMaxSize()) {
         Row(

--- a/app/src/main/java/com/github/se/gatherspot/ui/Profile.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/Profile.kt
@@ -30,6 +30,7 @@ fun Profile(nav: NavigationActions) {
     composable("edit") { ProfileView().EditOwnProfile(nav, viewModel, navController) }
   }
 }
+
 /**
  * Show the profile of another user
  *

--- a/app/src/main/java/com/github/se/gatherspot/ui/profile/ProfileView.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/profile/ProfileView.kt
@@ -130,6 +130,7 @@ class ProfileView {
                       .testTag("save"))
         }
   }
+
   // TODO: add state for the buttons for better ui when we have time, I want to catch up to
   // propagate functionalities first
   @Composable

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.2.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
-    id("com.google.gms.google-services") version "4.4.1" apply false
-    id ("com.google.android.libraries.mapsplatform.secrets-gradle-plugin") version "2.0.1" apply false
+  id("com.android.application") version "8.2.2" apply false
+  id("org.jetbrains.kotlin.android") version "1.9.0" apply false
+  id("com.google.gms.google-services") version "4.4.1" apply false
+  id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin") version "2.0.1" apply false
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,24 +1,25 @@
 pluginManagement {
-    repositories {
-        google {
-            content {
-                includeGroupByRegex("com\\.android.*")
-                includeGroupByRegex("com\\.google.*")
-                includeGroupByRegex("androidx.*")
-            }
-        }
-        mavenCentral()
-        gradlePluginPortal()
+  repositories {
+    google {
+      content {
+        includeGroupByRegex("com\\.android.*")
+        includeGroupByRegex("com\\.google.*")
+        includeGroupByRegex("androidx.*")
+      }
     }
+    mavenCentral()
+    gradlePluginPortal()
+  }
 }
+
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
-    }
+  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  repositories {
+    google()
+    mavenCentral()
+  }
 }
 
 rootProject.name = "GatherSpot"
+
 include(":app")
- 


### PR DESCRIPTION
The PR for this sprint contains the following changes:
- Status of events is not used anymore: in the main screen, only "organizer" , "registered" or nothing appears depending on the current user.
- Only events whose startDate is in the future are loaded by default (which required a change the storing format of the date to "yyy-MM-dd")
- Modified the LocalDateTime serialiser to LocalTime serializer, because of a type mismatch (was created by Samuel initially).
- Fixed UI displayed when an organizer wants to modify details of its event.