### PR TITLE
Only clean events are saved on firebase

### DIFF
--- a/app/src/androidTest/java/com/github/se/gatherspot/EnvironmentSetter.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/EnvironmentSetter.kt
@@ -27,6 +27,14 @@ class EnvironmentSetter {
       }
     }
 
+    fun melvinLogin() {
+      runBlocking {
+        Firebase.auth
+            .signInWithEmailAndPassword("melvinmalongamatouba@gmail.com", "Password12")
+            .await()
+      }
+    }
+
     fun testLoginCleanUp() {
       Firebase.auth.signOut()
     }

--- a/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
@@ -299,14 +299,18 @@ class EventFirebaseConnectionTest {
     assertEquals(resultEvent!!.title, "Test Event")
     assertEquals(resultEvent!!.description, "This is a test event")
     assertEquals(resultEvent!!.location, null)
-    assertEquals(resultEvent!!.eventStartDate, null)
-    assertEquals(resultEvent!!.eventEndDate, null)
-    assertEquals(resultEvent!!.timeBeginning, null)
-    assertEquals(resultEvent!!.timeEnding, null)
+    assertEquals(
+        resultEvent!!.eventStartDate, eventFirebaseConnection.EVENT_START_DATE_DEFAULT_VALUE)
+    assertEquals(resultEvent!!.eventEndDate, eventFirebaseConnection.EVENT_END_DATE_DEFAULT_VALUE)
+    assertEquals(
+        resultEvent!!.timeBeginning, eventFirebaseConnection.EVENT_START_TIME_DEFAULT_VALUE)
+    assertEquals(resultEvent!!.timeEnding, eventFirebaseConnection.EVENT_END_TIME_DEFAULT_VALUE)
     assertEquals(resultEvent!!.attendanceMaxCapacity, null)
     assertEquals(resultEvent!!.attendanceMinCapacity, 10)
-    assertEquals(resultEvent!!.inscriptionLimitDate, null)
-    assertEquals(resultEvent!!.inscriptionLimitTime, null)
+    assertEquals(
+        resultEvent!!.inscriptionLimitDate, eventFirebaseConnection.EVENT_END_DATE_DEFAULT_VALUE)
+    assertEquals(
+        resultEvent!!.inscriptionLimitTime, eventFirebaseConnection.EVENT_END_TIME_DEFAULT_VALUE)
     assertEquals(resultEvent!!.eventStatus, EventStatus.CREATED)
     assertEquals(resultEvent!!.categories, setOf(Interests.CHESS))
     assertEquals(resultEvent!!.registeredUsers!!.size, 0)

--- a/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
@@ -120,8 +120,7 @@ class EventFirebaseConnectionTest {
     assertEquals(resultEvent!!.registeredUsers!!.size, 0)
     assertEquals(resultEvent!!.finalAttendees!!.size, 0)
     assertEquals(resultEvent!!.image, "")
-    EventFirebaseConnection.delete(eventID)
-
+    eventFirebaseConnection.delete(eventID)
   }
 
   @Test
@@ -313,7 +312,7 @@ class EventFirebaseConnectionTest {
     assertEquals(resultEvent!!.registeredUsers!!.size, 0)
     assertEquals(resultEvent!!.finalAttendees!!.size, 0)
     assertEquals(resultEvent!!.image, "")
-    EventFirebaseConnection.delete(eventID)
+    eventFirebaseConnection.delete(eventID)
   }
 
   @Test

--- a/app/src/androidTest/java/com/github/se/gatherspot/model/EventTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/model/EventTest.kt
@@ -37,7 +37,7 @@ class EventTest {
             registeredUsers = mutableListOf(),
             timeBeginning = LocalTime.of(13, 0),
             timeEnding = LocalTime.of(16, 0),
-        )
+            image = "testToJSon")
 
     val json = event.toJson()
 

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventUITest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventUITest.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.navigation.compose.rememberNavController
+import com.github.se.gatherspot.EnvironmentSetter.Companion.melvinLogin
+import com.github.se.gatherspot.EnvironmentSetter.Companion.profileFirebaseConnection
 import com.github.se.gatherspot.EnvironmentSetter.Companion.testLogin
 import com.github.se.gatherspot.EnvironmentSetter.Companion.testLoginCleanUp
 import com.github.se.gatherspot.firebase.EventFirebaseConnection
@@ -32,6 +34,7 @@ class EventUITest {
   @Before
   fun setUp() {
     testLogin()
+    profileFirebaseConnection.add(Profile.testOrganizer())
   }
 
   @After
@@ -394,7 +397,7 @@ class EventUITest {
 
   @Test
   fun testOrganiserDeleteEditButtonAreHere() {
-    testLogin()
+    melvinLogin()
     composeTestRule.setContent {
       val navController = rememberNavController()
       val event =
@@ -432,6 +435,7 @@ class EventUITest {
   @OptIn(ExperimentalTestApi::class)
   @Test
   fun testClickOnDeleteButton() {
+    melvinLogin()
     composeTestRule.setContent {
       val navController = rememberNavController()
       val event =
@@ -482,7 +486,6 @@ class EventUITest {
 
   @Test
   fun testProfileIsCorrectlyFetched() {
-    testLogin()
     composeTestRule.setContent {
       val navController = rememberNavController()
       val event =

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventUITest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventUITest.kt
@@ -394,6 +394,7 @@ class EventUITest {
 
   @Test
   fun testOrganiserDeleteEditButtonAreHere() {
+    testLogin()
     composeTestRule.setContent {
       val navController = rememberNavController()
       val event =
@@ -502,7 +503,7 @@ class EventUITest {
               timeBeginning = LocalTime.of(13, 0),
               globalRating = 4,
               timeEnding = LocalTime.of(16, 0),
-          )
+              image = "EventUITestImage")
 
       EventUI(
           event,

--- a/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
@@ -31,10 +31,20 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
     val DATE_FORMAT_STORED = "yyyy/MM/dd"
     val TIME_FORMAT = "HH:mm"
   }
-    val BATTLE_OF_THE_APPS_START_DATE = LocalDate.parse("2024/05/28", DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
-    val BATTLE_OF_THE_APPS_END_DATE = LocalDate.parse("2024/05/28", DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
-    val BATTLE_OF_THE_APPS_START_TIME = LocalTime.parse("10:15", DateTimeFormatter.ofPattern(TIME_FORMAT))
-    val BATTLE_OF_THE_APPS_END_TIME = LocalTime.parse("12:00", DateTimeFormatter.ofPattern(TIME_FORMAT))
+
+  val BATTLE_OF_THE_APPS_START_DATE =
+      LocalDate.parse("2024/05/28", DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
+  val BATTLE_OF_THE_APPS_END_DATE =
+      LocalDate.parse("2024/05/28", DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
+  val BATTLE_OF_THE_APPS_START_TIME =
+      LocalTime.parse("10:15", DateTimeFormatter.ofPattern(TIME_FORMAT))
+  val BATTLE_OF_THE_APPS_END_TIME =
+      LocalTime.parse("12:00", DateTimeFormatter.ofPattern(TIME_FORMAT))
+
+  val EVENT_START_DATE_DEFAULT_VALUE = BATTLE_OF_THE_APPS_START_DATE
+  val EVENT_END_DATE_DEFAULT_VALUE = BATTLE_OF_THE_APPS_END_DATE
+  val EVENT_START_TIME_DEFAULT_VALUE = BATTLE_OF_THE_APPS_START_TIME
+  val EVENT_END_TIME_DEFAULT_VALUE = BATTLE_OF_THE_APPS_END_TIME
 
   var offset: DocumentSnapshot? = null
 
@@ -323,18 +333,18 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
    * @param element: The event to add
    */
   override fun add(element: Event) {
-      val eventItem =
+    val eventItem =
         hashMapOf(
             "eventID" to
-                when (element.id){
-                    "" -> getNewID()
-                    else -> element.id
-                 },
+                when (element.id) {
+                  "" -> getNewID()
+                  else -> element.id
+                },
             "title" to
-                    when (element.title){
-                                    "" -> element.id
-                                    else -> element.title
-                                        },
+                when (element.title) {
+                  "" -> element.id
+                  else -> element.title
+                },
             "description" to element.description,
             "locationLatitude" to
                 when (element.location) {
@@ -353,25 +363,32 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
                 },
             "eventStartDate" to
                 when (element.eventStartDate) {
-                  null -> BATTLE_OF_THE_APPS_START_DATE.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
+                  null ->
+                      EVENT_START_DATE_DEFAULT_VALUE.format(
+                          DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
                   else ->
                       element.eventStartDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
                 },
             "eventEndDate" to
                 when (element.eventEndDate) {
-                  null -> BATTLE_OF_THE_APPS_END_DATE.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
+                  null ->
+                      EVENT_END_DATE_DEFAULT_VALUE.format(
+                          DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
                   else ->
                       element.eventEndDate.format(
                           DateTimeFormatter.ofPattern(DATE_FORMAT_DISPLAYED))
                 },
             "timeBeginning" to
                 when (element.timeBeginning) {
-                  null -> BATTLE_OF_THE_APPS_START_TIME.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
+                  null ->
+                      EVENT_START_TIME_DEFAULT_VALUE.format(
+                          DateTimeFormatter.ofPattern(TIME_FORMAT))
                   else -> element.timeBeginning.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                 },
             "timeEnding" to
                 when (element.timeEnding) {
-                  null -> BATTLE_OF_THE_APPS_END_TIME.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
+                  null ->
+                      EVENT_END_TIME_DEFAULT_VALUE.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                   else -> element.timeEnding.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                 },
             "attendanceMaxCapacity" to
@@ -382,34 +399,42 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
             "attendanceMinCapacity" to element.attendanceMinCapacity.toString(),
             "inscriptionLimitDate" to
                 when (element.inscriptionLimitDate) {
-                  null -> element.eventEndDate?.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)) ?: element.eventStartDate?.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)) ?: BATTLE_OF_THE_APPS_START_DATE.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
+                  null ->
+                      element.eventEndDate?.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
+                          ?: EVENT_START_DATE_DEFAULT_VALUE.format(
+                              DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
                   else ->
                       element.inscriptionLimitDate.format(
                           DateTimeFormatter.ofPattern(DATE_FORMAT_DISPLAYED))
                 },
             "inscriptionLimitTime" to
                 when (element.inscriptionLimitTime) {
-                  null -> element.timeEnding?.format(DateTimeFormatter.ofPattern(TIME_FORMAT)) ?: element.timeEnding?.format(DateTimeFormatter.ofPattern(TIME_FORMAT)) ?: BATTLE_OF_THE_APPS_END_TIME.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
+                  null ->
+                      element.timeEnding?.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
+                          ?: EVENT_END_TIME_DEFAULT_VALUE.format(
+                              DateTimeFormatter.ofPattern(TIME_FORMAT))
                   else ->
                       element.inscriptionLimitTime.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                 },
             "categories" to element.categories?.toList(),
             "registeredUsers" to element.registeredUsers,
-            "finalAttendee" to when (element.finalAttendees) { //TODO Harmonize spelling to one or the other
-                null -> mutableListOf<String>()
-              else -> element.finalAttendees
-            },
-            "globalRating" to  //TODO Change globalRating to an Int ?
+            "finalAttendee" to
+                when (element.finalAttendees) { // TODO Harmonize spelling to one or the other
+                  null -> mutableListOf<String>()
+                  else -> element.finalAttendees
+                },
+            "globalRating" to // TODO Change globalRating to an Int ?
                 when (element.globalRating) {
                   null -> "null"
                   else -> element.globalRating.toString()
                 },
             "image" to element.image,
-            "organizerID" to when (element.organizerID){
-                "" -> Firebase.auth.currentUser?.uid ?: Profile.testOrganizer().id
-                else -> element.organizerID
-                                                       },
-            "eventStatus" to element.eventStatus) //TODO remove ?
+            "organizerID" to
+                when (element.organizerID) {
+                  "" -> Firebase.auth.currentUser?.uid ?: Profile.testOrganizer().id
+                  else -> element.organizerID
+                },
+            "eventStatus" to element.eventStatus) // TODO remove ?
 
     Firebase.firestore
         .collection(EVENTS)
@@ -417,47 +442,4 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
         .set(eventItem)
         .addOnFailureListener { exception -> Log.e(TAG, "Error adding new Event", exception) }
   }
-
-    fun cleanCollection(){
-        Firebase.firestore
-            .collection(EVENTS)
-            .whereNotEqualTo("organizerID", "")
-            .get()
-            .addOnSuccessListener { querySnapshot ->
-                Log.d(TAG, "Found ${querySnapshot.documents.size} documents with non empty organizerID")
-                querySnapshot.documents.forEach { document ->
-                    Firebase.firestore
-                        .collection("clean_events")
-                        .document(document.id)
-                        .set(document.data!!)
-                        .addOnSuccessListener {
-                            Log.d(TAG, "DocumentSnapshot successfully moved to clean_events : ${document.id}")
-                        }
-                        .addOnFailureListener { e -> Log.w(TAG, "Error moving document", e) }
-                }
-
-            }
-            .addOnFailureListener { exception ->
-                Log.d(TAG, exception.toString())
-            }
-    }
-
-    fun retrieveEvents(){
-        Firebase.firestore
-            .collection("clean_events")
-            .get()
-            .addOnSuccessListener { querySnapshot ->
-                Log.d(TAG, "Found ${querySnapshot.documents.size} documents in clean_events")
-                querySnapshot.documents.forEach { document ->
-                    val event = getFromDocument(document)
-                    if (event != null) {
-                        add(event)
-                    }
-                }
-            }
-            .addOnFailureListener { exception ->
-                Log.d(TAG, exception.toString())
-            }
-    }
-
 }

--- a/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
@@ -9,6 +9,7 @@ import com.github.se.gatherspot.model.event.EventStatus
 import com.github.se.gatherspot.model.location.Location
 import com.google.firebase.Firebase
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.auth
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.QuerySnapshot
@@ -30,6 +31,10 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
     val DATE_FORMAT_STORED = "yyyy/MM/dd"
     val TIME_FORMAT = "HH:mm"
   }
+    val BATTLE_OF_THE_APPS_START_DATE = LocalDate.parse("2024/05/28", DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
+    val BATTLE_OF_THE_APPS_END_DATE = LocalDate.parse("2024/05/28", DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
+    val BATTLE_OF_THE_APPS_START_TIME = LocalTime.parse("10:15", DateTimeFormatter.ofPattern(TIME_FORMAT))
+    val BATTLE_OF_THE_APPS_END_TIME = LocalTime.parse("12:00", DateTimeFormatter.ofPattern(TIME_FORMAT))
 
   var offset: DocumentSnapshot? = null
 
@@ -318,10 +323,18 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
    * @param element: The event to add
    */
   override fun add(element: Event) {
-    val eventItem =
+      val eventItem =
         hashMapOf(
-            "eventID" to element.id,
-            "title" to element.title,
+            "eventID" to
+                when (element.id){
+                    "" -> getNewID()
+                    else -> element.id
+                 },
+            "title" to
+                    when (element.title){
+                                    "" -> element.id
+                                    else -> element.title
+                                        },
             "description" to element.description,
             "locationLatitude" to
                 when (element.location) {
@@ -340,25 +353,25 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
                 },
             "eventStartDate" to
                 when (element.eventStartDate) {
-                  null -> "null"
+                  null -> BATTLE_OF_THE_APPS_START_DATE.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
                   else ->
                       element.eventStartDate.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
                 },
             "eventEndDate" to
                 when (element.eventEndDate) {
-                  null -> "null"
+                  null -> BATTLE_OF_THE_APPS_END_DATE.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
                   else ->
                       element.eventEndDate.format(
                           DateTimeFormatter.ofPattern(DATE_FORMAT_DISPLAYED))
                 },
             "timeBeginning" to
                 when (element.timeBeginning) {
-                  null -> "null"
+                  null -> BATTLE_OF_THE_APPS_START_TIME.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                   else -> element.timeBeginning.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                 },
             "timeEnding" to
                 when (element.timeEnding) {
-                  null -> "null"
+                  null -> BATTLE_OF_THE_APPS_END_TIME.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                   else -> element.timeEnding.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                 },
             "attendanceMaxCapacity" to
@@ -369,28 +382,34 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
             "attendanceMinCapacity" to element.attendanceMinCapacity.toString(),
             "inscriptionLimitDate" to
                 when (element.inscriptionLimitDate) {
-                  null -> "null"
+                  null -> element.eventEndDate?.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)) ?: element.eventStartDate?.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)) ?: BATTLE_OF_THE_APPS_START_DATE.format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED))
                   else ->
                       element.inscriptionLimitDate.format(
                           DateTimeFormatter.ofPattern(DATE_FORMAT_DISPLAYED))
                 },
             "inscriptionLimitTime" to
                 when (element.inscriptionLimitTime) {
-                  null -> "null"
+                  null -> element.timeEnding?.format(DateTimeFormatter.ofPattern(TIME_FORMAT)) ?: element.timeEnding?.format(DateTimeFormatter.ofPattern(TIME_FORMAT)) ?: BATTLE_OF_THE_APPS_END_TIME.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                   else ->
                       element.inscriptionLimitTime.format(DateTimeFormatter.ofPattern(TIME_FORMAT))
                 },
             "categories" to element.categories?.toList(),
             "registeredUsers" to element.registeredUsers,
-            "finalAttendee" to element.finalAttendees,
-            "globalRating" to
+            "finalAttendee" to when (element.finalAttendees) { //TODO Harmonize spelling to one or the other
+                null -> mutableListOf<String>()
+              else -> element.finalAttendees
+            },
+            "globalRating" to  //TODO Change globalRating to an Int ?
                 when (element.globalRating) {
                   null -> "null"
                   else -> element.globalRating.toString()
                 },
             "image" to element.image,
-            "organizerID" to element.organizerID,
-            "eventStatus" to element.eventStatus)
+            "organizerID" to when (element.organizerID){
+                "" -> Firebase.auth.currentUser?.uid ?: Profile.testOrganizer().id
+                else -> element.organizerID
+                                                       },
+            "eventStatus" to element.eventStatus) //TODO remove ?
 
     Firebase.firestore
         .collection(EVENTS)
@@ -398,4 +417,47 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
         .set(eventItem)
         .addOnFailureListener { exception -> Log.e(TAG, "Error adding new Event", exception) }
   }
+
+    fun cleanCollection(){
+        Firebase.firestore
+            .collection(EVENTS)
+            .whereNotEqualTo("organizerID", "")
+            .get()
+            .addOnSuccessListener { querySnapshot ->
+                Log.d(TAG, "Found ${querySnapshot.documents.size} documents with non empty organizerID")
+                querySnapshot.documents.forEach { document ->
+                    Firebase.firestore
+                        .collection("clean_events")
+                        .document(document.id)
+                        .set(document.data!!)
+                        .addOnSuccessListener {
+                            Log.d(TAG, "DocumentSnapshot successfully moved to clean_events : ${document.id}")
+                        }
+                        .addOnFailureListener { e -> Log.w(TAG, "Error moving document", e) }
+                }
+
+            }
+            .addOnFailureListener { exception ->
+                Log.d(TAG, exception.toString())
+            }
+    }
+
+    fun retrieveEvents(){
+        Firebase.firestore
+            .collection("clean_events")
+            .get()
+            .addOnSuccessListener { querySnapshot ->
+                Log.d(TAG, "Found ${querySnapshot.documents.size} documents in clean_events")
+                querySnapshot.documents.forEach { document ->
+                    val event = getFromDocument(document)
+                    if (event != null) {
+                        add(event)
+                    }
+                }
+            }
+            .addOnFailureListener { exception ->
+                Log.d(TAG, exception.toString())
+            }
+    }
+
 }

--- a/app/src/main/java/com/github/se/gatherspot/model/event/Event.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/event/Event.kt
@@ -1,5 +1,6 @@
 package com.github.se.gatherspot.model.event
 
+import androidx.compose.ui.graphics.ImageBitmap
 import com.github.se.gatherspot.firebase.CollectionClass
 import com.github.se.gatherspot.model.Interests
 import com.github.se.gatherspot.model.location.Location

--- a/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/Events.kt
@@ -239,7 +239,7 @@ fun EventRow(event: Event, navigation: NavigationActions) {
   val isToday = event.eventStartDate?.isEqual(LocalDate.now()) ?: false
   val isOrganizer = event.organizerID == uid
   val isRegistered = event.registeredUsers.contains(uid)
-  
+
   Box(
       modifier =
           Modifier.background(
@@ -262,57 +262,59 @@ fun EventRow(event: Event, navigation: NavigationActions) {
               }
               .testTag(event.title)
               .fillMaxSize()) {
-        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(vertical = 16.dp, horizontal = 10.dp)) {
-          Column(modifier = Modifier.weight(1f)) {
-              // TODO : use coil to implement this
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 16.dp, horizontal = 10.dp)) {
+              Column(modifier = Modifier.weight(1f)) {
+                // TODO : use coil to implement this
                 //                Image(
                 //                    bitmap =
                 //                        event.image ?: ImageBitmap(120, 120, config =
                 // ImageBitmapConfig.Rgb565),
                 //                    contentDescription = null)
-          }
+              }
 
-          Column(modifier = Modifier.weight(1f).padding(end = 1.dp)) {
-            Text(
-                text =
-                    "Start date: ${
+              Column(modifier = Modifier.weight(1f).padding(end = 1.dp)) {
+                Text(
+                    text =
+                        "Start date: ${
                             event.eventStartDate?.format(
                                 DateTimeFormatter.ofPattern(
                                     EventFirebaseConnection.DATE_FORMAT_DISPLAYED
                                 )
                             )
                         }",
-                fontWeight = FontWeight.Bold,
-                fontSize = 10.sp)
-            Text(
-                text =
-                    "End date: ${
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 10.sp)
+                Text(
+                    text =
+                        "End date: ${
                             event.eventEndDate?.format(
                                 DateTimeFormatter.ofPattern(
                                     EventFirebaseConnection.DATE_FORMAT_DISPLAYED
                                 )
                             )
                         }",
-                fontWeight = FontWeight.Bold,
-                fontSize = 10.sp)
-            Text(text = event.title, fontSize = 14.sp)
-          }
-
-          Column(horizontalAlignment = Alignment.End, modifier = Modifier.weight(1f)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-              if (isOrganizer) {
-                Text("Organizer", fontSize = 14.sp)
-              } else if (isRegistered) {
-                Text("Registered", fontSize = 14.sp)
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 10.sp)
+                Text(text = event.title, fontSize = 14.sp)
               }
 
-              Icon(
-                  painter = painterResource(R.drawable.arrow_right),
-                  contentDescription = null,
-                  modifier = Modifier.width(24.dp).height(24.dp).clickable {})
+              Column(horizontalAlignment = Alignment.End, modifier = Modifier.weight(1f)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                  if (isOrganizer) {
+                    Text("Organizer", fontSize = 14.sp)
+                  } else if (isRegistered) {
+                    Text("Registered", fontSize = 14.sp)
+                  }
+
+                  Icon(
+                      painter = painterResource(R.drawable.arrow_right),
+                      contentDescription = null,
+                      modifier = Modifier.width(24.dp).height(24.dp).clickable {})
+                }
+              }
             }
-          }
-        }
         Divider(color = Color.Black, thickness = 1.dp)
       }
 }


### PR DESCRIPTION
Events Firebase Connection now gives default value to critical fields when pushing events onto firebase. 

It would not make sense to have these changes at model level as tests might not need to instantiate all fields to test a particular aspect and the actual user flows restricts the value many fields can take (For example organizerID, it is either retrieved from Firebase, so already a clean value or the event is being added. If the event is being added then the organizer is necessarily the user logged in.) 
Tests have been adapted in consequence.