### PR TITLE
Attending button

### DIFF
--- a/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
@@ -25,50 +25,50 @@ import org.junit.Test
 class EventFirebaseConnectionTest {
 
   val eventFirebaseConnection = EventFirebaseConnection()
-    
-    val event1 = Event(
-        id = "efcTest1",
-        title = "efcTest1Title",
-        description = "",
-        location = null,
-        eventStartDate = null,
-        eventEndDate = null,
-        timeBeginning = null,
-        timeEnding = null,
-        attendanceMaxCapacity = null,
-        attendanceMinCapacity = 3013,
-        inscriptionLimitDate = null,
-        inscriptionLimitTime = null,
-        eventStatus = EventStatus.CREATED,
-        categories = setOf(),
-        organizerID = "efcTestOrganizerNOTID",
-        registeredUsers = mutableListOf(),
-        finalAttendees = mutableListOf(),
-        image = "",
-        globalRating = null
-    )
 
-    val event2 = Event(
-        id = "efcTest2",
-        title = "efcTest2Title",
-        description = "",
-        location = null,
-        eventStartDate = null,
-        eventEndDate = null,
-        timeBeginning = null,
-        timeEnding = null,
-        attendanceMaxCapacity = null,
-        attendanceMinCapacity = 3013,
-        inscriptionLimitDate = null,
-        inscriptionLimitTime = null,
-        eventStatus = EventStatus.CREATED,
-        categories = setOf(),
-        organizerID = "efcTestOrganizerNOTID",
-        registeredUsers = mutableListOf(),
-        finalAttendees = mutableListOf(),
-        image = "",
-        globalRating = null
-    )
+  val event1 =
+      Event(
+          id = "efcTest1",
+          title = "efcTest1Title",
+          description = "",
+          location = null,
+          eventStartDate = null,
+          eventEndDate = null,
+          timeBeginning = null,
+          timeEnding = null,
+          attendanceMaxCapacity = null,
+          attendanceMinCapacity = 3013,
+          inscriptionLimitDate = null,
+          inscriptionLimitTime = null,
+          eventStatus = EventStatus.CREATED,
+          categories = setOf(),
+          organizerID = "efcTestOrganizerNOTID",
+          registeredUsers = mutableListOf(),
+          finalAttendees = mutableListOf(),
+          image = "",
+          globalRating = null)
+
+  val event2 =
+      Event(
+          id = "efcTest2",
+          title = "efcTest2Title",
+          description = "",
+          location = null,
+          eventStartDate = null,
+          eventEndDate = null,
+          timeBeginning = null,
+          timeEnding = null,
+          attendanceMaxCapacity = null,
+          attendanceMinCapacity = 3013,
+          inscriptionLimitDate = null,
+          inscriptionLimitTime = null,
+          eventStatus = EventStatus.CREATED,
+          categories = setOf(),
+          organizerID = "efcTestOrganizerNOTID",
+          registeredUsers = mutableListOf(),
+          finalAttendees = mutableListOf(),
+          image = "",
+          globalRating = null)
 
   @Test
   fun testgetID() {
@@ -274,20 +274,20 @@ class EventFirebaseConnectionTest {
         testLoginCleanUp()
       }
 
-    @Test
-    fun fetchAttendedWorks() =
-        runTest(timeout = Duration.parse("20s")) {
-            testLogin()
+  @Test
+  fun fetchAttendedWorks() =
+      runTest(timeout = Duration.parse("20s")) {
+        testLogin()
 
-            Thread.sleep(3000)
-            val events = eventFirebaseConnection.fetchAttended()
-            assert(
-                events.all { event ->
-                    (event.finalAttendees == null ||
-                    event.finalAttendees!!.contains(FirebaseAuth.getInstance().currentUser!!.uid))
-                })
-            testLoginCleanUp()
-        }
+        Thread.sleep(3000)
+        val events = eventFirebaseConnection.fetchAttended()
+        assert(
+            events.all { event ->
+              (event.finalAttendees == null ||
+                  event.finalAttendees!!.contains(FirebaseAuth.getInstance().currentUser!!.uid))
+            })
+        testLoginCleanUp()
+      }
 
   @Test
   fun fetchEventsFromFollowedWorks() =
@@ -299,52 +299,49 @@ class EventFirebaseConnectionTest {
         testLoginCleanUp()
       }
 
-    @Test
-    fun testAddRegisteredWorks(){
-        runBlocking {
-            eventFirebaseConnection.add(event1)
-            eventFirebaseConnection.add(event2)
-            eventFirebaseConnection.addRegisteredUser(event1.id, "efctestUser")
+  @Test
+  fun testAddRegisteredWorks() {
+    runBlocking {
+      eventFirebaseConnection.add(event1)
+      eventFirebaseConnection.add(event2)
+      eventFirebaseConnection.addRegisteredUser(event1.id, "efctestUser")
 
-            delay(400)
+      delay(400)
 
-            val fetch1 = async {eventFirebaseConnection.fetch(event1.id) as Event}.await()
-            val fetch2 = async {eventFirebaseConnection.fetch(event2.id) as Event}.await()
+      val fetch1 = async { eventFirebaseConnection.fetch(event1.id) as Event }.await()
+      val fetch2 = async { eventFirebaseConnection.fetch(event2.id) as Event }.await()
 
-            assert(fetch1.registeredUsers.contains("efctestUser"))
-            assert(!fetch2.registeredUsers.contains("efctestUser"))
+      assert(fetch1.registeredUsers.contains("efctestUser"))
+      assert(!fetch2.registeredUsers.contains("efctestUser"))
 
-            eventFirebaseConnection.delete(event1.id)
-            eventFirebaseConnection.delete(event2.id)
+      eventFirebaseConnection.delete(event1.id)
+      eventFirebaseConnection.delete(event2.id)
 
-            delay(400)
-
-        }
+      delay(400)
     }
+  }
 
-    @Test
-    fun testAddFinalAttendeeWorks(){
-        runBlocking {
-            eventFirebaseConnection.add(event1)
-            eventFirebaseConnection.add(event2)
-            eventFirebaseConnection.addFinalAttendee(event1.id, "efctestUser")
+  @Test
+  fun testAddFinalAttendeeWorks() {
+    runBlocking {
+      eventFirebaseConnection.add(event1)
+      eventFirebaseConnection.add(event2)
+      eventFirebaseConnection.addFinalAttendee(event1.id, "efctestUser")
 
-            delay(400)
+      delay(400)
 
-            val fetch1 = async {eventFirebaseConnection.fetch(event1.id) as Event}.await()
-            val fetch2 = async {eventFirebaseConnection.fetch(event2.id) as Event}.await()
+      val fetch1 = async { eventFirebaseConnection.fetch(event1.id) as Event }.await()
+      val fetch2 = async { eventFirebaseConnection.fetch(event2.id) as Event }.await()
 
-            assert(fetch1.finalAttendees?.contains("efctestUser")==true)
-            assert(fetch2.finalAttendees?.contains("efctestUser")!=true)
+      assert(fetch1.finalAttendees?.contains("efctestUser") == true)
+      assert(fetch2.finalAttendees?.contains("efctestUser") != true)
 
-            //eventFirebaseConnection.delete(event1.id)
-            //eventFirebaseConnection.delete(event2.id)
+      // eventFirebaseConnection.delete(event1.id)
+      // eventFirebaseConnection.delete(event2.id)
 
-            delay(400)
-
-        }
+      delay(400)
     }
-
+  }
 
   @Test
   fun deleteEvent() = runTest {

--- a/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
@@ -337,8 +337,8 @@ class EventFirebaseConnectionTest {
             assert(fetch1.finalAttendees?.contains("efctestUser")==true)
             assert(fetch2.finalAttendees?.contains("efctestUser")!=true)
 
-            eventFirebaseConnection.delete(event1.id)
-            eventFirebaseConnection.delete(event2.id)
+            //eventFirebaseConnection.delete(event1.id)
+            //eventFirebaseConnection.delete(event2.id)
 
             delay(400)
 

--- a/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/firebase/EventFirebaseConnectionTest.kt
@@ -266,7 +266,7 @@ class EventFirebaseConnectionTest {
         testLogin()
 
         Thread.sleep(3000)
-        val events = eventFirebaseConnection.fetchRegisteredTo()
+        val events = eventFirebaseConnection.fetchUpComing()
         assert(
             events.all { event ->
               event.registeredUsers.contains(FirebaseAuth.getInstance().currentUser!!.uid)

--- a/app/src/androidTest/java/com/github/se/gatherspot/run/model/EventUtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/run/model/EventUtilsTest.kt
@@ -599,4 +599,31 @@ class EventUtilsTest {
             image = "")
     assert(eventUtils.isEventOver(event))
   }
+
+    @Test
+    fun eventIsStartedTestNotStarted() {
+        assert(!eventUtils.isEventStarted(testEvent))
+    }
+
+    @Test
+    fun eventIsStartedReturnTrue() {
+        val event =
+            Event(
+                id = "testID",
+                title = "Test Event",
+                description = "This is a test event",
+                location = null,
+                eventStartDate = LocalDate.of(2020, 4, 12),
+                eventEndDate = LocalDate.of(2020, 4, 12),
+                timeBeginning = LocalTime.of(10, 0),
+                timeEnding = LocalTime.of(12, 0),
+                attendanceMaxCapacity = 100,
+                attendanceMinCapacity = 10,
+                inscriptionLimitDate = LocalDate.of(2020, 4, 11),
+                inscriptionLimitTime = LocalTime.of(23, 59),
+                eventStatus = EventStatus.COMPLETED,
+                globalRating = null,
+                image = "")
+        assert(eventUtils.isEventStarted(event))
+    }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/run/model/EventUtilsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/run/model/EventUtilsTest.kt
@@ -600,30 +600,30 @@ class EventUtilsTest {
     assert(eventUtils.isEventOver(event))
   }
 
-    @Test
-    fun eventIsStartedTestNotStarted() {
-        assert(!eventUtils.isEventStarted(testEvent))
-    }
+  @Test
+  fun eventIsStartedTestNotStarted() {
+    assert(!eventUtils.isEventStarted(testEvent))
+  }
 
-    @Test
-    fun eventIsStartedReturnTrue() {
-        val event =
-            Event(
-                id = "testID",
-                title = "Test Event",
-                description = "This is a test event",
-                location = null,
-                eventStartDate = LocalDate.of(2020, 4, 12),
-                eventEndDate = LocalDate.of(2020, 4, 12),
-                timeBeginning = LocalTime.of(10, 0),
-                timeEnding = LocalTime.of(12, 0),
-                attendanceMaxCapacity = 100,
-                attendanceMinCapacity = 10,
-                inscriptionLimitDate = LocalDate.of(2020, 4, 11),
-                inscriptionLimitTime = LocalTime.of(23, 59),
-                eventStatus = EventStatus.COMPLETED,
-                globalRating = null,
-                image = "")
-        assert(eventUtils.isEventStarted(event))
-    }
+  @Test
+  fun eventIsStartedReturnTrue() {
+    val event =
+        Event(
+            id = "testID",
+            title = "Test Event",
+            description = "This is a test event",
+            location = null,
+            eventStartDate = LocalDate.of(2020, 4, 12),
+            eventEndDate = LocalDate.of(2020, 4, 12),
+            timeBeginning = LocalTime.of(10, 0),
+            timeEnding = LocalTime.of(12, 0),
+            attendanceMaxCapacity = 100,
+            attendanceMinCapacity = 10,
+            inscriptionLimitDate = LocalDate.of(2020, 4, 11),
+            inscriptionLimitTime = LocalTime.of(23, 59),
+            eventStatus = EventStatus.COMPLETED,
+            globalRating = null,
+            image = "")
+    assert(eventUtils.isEventStarted(event))
+  }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/screens/EventsScreen.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/screens/EventsScreen.kt
@@ -21,7 +21,8 @@ class EventsScreen(semanticsProvider: SemanticsNodeInteractionsProvider) :
   val categories: List<KNode> =
       enumValues<Interests>().toList().map { i -> onNode { hasTestTag(i.toString()) } }
   val myEvents: KNode = onNode { hasTestTag("myEvents") }
-  val registeredTo: KNode = onNode { hasTestTag("registeredTo") }
+  val upComing: KNode = onNode { hasTestTag("upComing") }
+  val attended: KNode = onNode { hasTestTag("attended") }
   val fromFollowed: KNode = onNode { hasTestTag("fromFollowed") }
   val removeFilter: KNode = onNode { hasTestTag("removeFilter") }
   val eventCreated: KNode = onNode { hasTestTag("Basketball Game") }

--- a/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/ui/EventsTest.kt
@@ -19,6 +19,8 @@ import com.github.se.gatherspot.ui.topLevelDestinations.Events
 import com.github.se.gatherspot.ui.topLevelDestinations.EventsViewModel
 import com.google.firebase.auth.FirebaseAuth
 import io.github.kakaocup.compose.node.element.ComposeScreen
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -308,8 +310,8 @@ class EventsTest {
 
       dropdown { assertIsDisplayed() }
 
-      registeredTo {
-        composeTestRule.onNodeWithTag("dropdown").performScrollToNode(hasTestTag("registeredTo"))
+      upComing {
+        composeTestRule.onNodeWithTag("dropdown").performScrollToNode(hasTestTag("upComing"))
         performClick()
       }
 
@@ -318,6 +320,38 @@ class EventsTest {
       val listOfEvents = viewModel.uiState.value.list
       if (listOfEvents.isNotEmpty()) {
         assert(listOfEvents.all { event -> event.registeredUsers.contains(uid) })
+      }
+    }
+  }
+
+  @Test
+  fun testAttendedWorks() {
+    val viewModel = EventsViewModel()
+    Thread.sleep(2000)
+    composeTestRule.setContent {
+      val nav = NavigationActions(rememberNavController())
+      Events(viewModel = viewModel, nav = nav)
+    }
+
+    ComposeScreen.onComposeScreen<EventsScreen>(composeTestRule) {
+      filterMenu {
+        assertIsDisplayed()
+        performClick()
+      }
+
+      dropdown { assertIsDisplayed() }
+
+      attended {
+        composeTestRule.onNodeWithTag("dropdown").performScrollToNode(hasTestTag("attended"))
+        performClick()
+      }
+
+      runBlocking { async { delay(2000) }.await() }
+      composeTestRule.waitForIdle()
+
+      val listOfEvents = viewModel.uiState.value.list
+      if (listOfEvents.isNotEmpty()) {
+        assert(listOfEvents.all { event -> (event.finalAttendees?.contains(uid) == true) })
       }
     }
   }

--- a/app/src/androidTest/java/com/github/se/gatherspot/viewModel/EventUIViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/viewModel/EventUIViewModelTest.kt
@@ -29,13 +29,6 @@ import org.junit.Test
 class EventUIViewModelTest {
   private val ratingFirebaseConnection = RatingFirebaseConnection()
 
-  private val organizer =
-      Profile(
-          userName = "organizer",
-          bio = "bio",
-          image = "image",
-          id = "eventUIViewModelTest",
-          interests = setOf())
   private val event =
       Event(
           id = "eventUIViewModelTest",
@@ -210,7 +203,6 @@ class EventUIViewModelTest {
   @Test
   fun testAlreadyRegistered(): Unit = runBlocking {
     if (Firebase.auth.currentUser == null) Log.d("testAlreadyRegistered", "User is null")
-    val viewModel = EventUIViewModel(event)
     val event =
         Event(
             id = "idTestEvent",
@@ -232,6 +224,8 @@ class EventUIViewModelTest {
             inscriptionLimitTime = null,
             image = "")
 
+  val viewModel = EventUIViewModel(event)
+
     val eventFirebaseConnection = EventFirebaseConnection()
     eventFirebaseConnection.add(event)
     viewModel.registerForEvent(event)
@@ -247,4 +241,37 @@ class EventUIViewModelTest {
     EventFirebaseConnection().delete("idTestEvent")
     EnvironmentSetter.testLoginCleanUp()
   }
+
+@Test
+fun testAttendAsOrganizer() {
+    runBlocking {
+        val viewModel = EventUIViewModel(organizedEvent)
+        delay(1000)
+        assertEquals(false, viewModel.attended.value)
+        viewModel.attendEvent()
+        delay(1000)
+        assertEquals(false, viewModel.attended.value)
+    }
+}
+
+    @Test
+    fun testAttendEvent() {
+        runBlocking {
+            EventFirebaseConnection().add(event)
+            val viewModel = EventUIViewModel(event)
+            delay(1000)
+            assertEquals(false, viewModel.attended.value)
+            val uid = Firebase.auth.currentUser?.uid
+            viewModel.attendEvent() //not registered so attempt to attend should fail
+            delay(1000)
+            assertEquals(false, viewModel.attended.value)
+
+            viewModel.registerForEvent(event)
+            delay(400)
+            viewModel.attendEvent()
+            delay(1000)
+            assertEquals(true, viewModel.attended.value)
+
+        }
+    }
 }

--- a/app/src/androidTest/java/com/github/se/gatherspot/viewModel/EventUIViewModelTest.kt
+++ b/app/src/androidTest/java/com/github/se/gatherspot/viewModel/EventUIViewModelTest.kt
@@ -28,9 +28,9 @@ import org.junit.Test
 
 class EventUIViewModelTest {
   private val ratingFirebaseConnection = RatingFirebaseConnection()
-    private val eventFirebaseConnection = EventFirebaseConnection()
+  private val eventFirebaseConnection = EventFirebaseConnection()
 
-  private val event = //isOver
+  private val event = // isOver
       Event(
           id = "eventUIViewModelTest",
           title = "",
@@ -52,27 +52,27 @@ class EventUIViewModelTest {
           image = "",
           globalRating = null)
 
-    private val event2 = //isStarted but is not Over
-        Event(
-            id = "eventUIViewModelTest2",
-            title = "",
-            description = null,
-            location = null,
-            eventStartDate = LocalDate.of(2024, 5, 10),
-            eventEndDate = LocalDate.of(2026, 5, 11),
-            timeBeginning = null,
-            timeEnding = null,
-            attendanceMaxCapacity = null,
-            attendanceMinCapacity = 0,
-            inscriptionLimitDate = null,
-            inscriptionLimitTime = null,
-            eventStatus = EventStatus.CREATED,
-            categories = setOf(),
-            organizerID = "T1qNNU05QeeqB2OqIBb7GAtQd093",
-            registeredUsers = mutableListOf(),
-            finalAttendees = listOf(),
-            image = "",
-            globalRating = null)
+  private val event2 = // isStarted but is not Over
+      Event(
+          id = "eventUIViewModelTest2",
+          title = "",
+          description = null,
+          location = null,
+          eventStartDate = LocalDate.of(2024, 5, 10),
+          eventEndDate = LocalDate.of(2026, 5, 11),
+          timeBeginning = null,
+          timeEnding = null,
+          attendanceMaxCapacity = null,
+          attendanceMinCapacity = 0,
+          inscriptionLimitDate = null,
+          inscriptionLimitTime = null,
+          eventStatus = EventStatus.CREATED,
+          categories = setOf(),
+          organizerID = "T1qNNU05QeeqB2OqIBb7GAtQd093",
+          registeredUsers = mutableListOf(),
+          finalAttendees = listOf(),
+          image = "",
+          globalRating = null)
 
   private val organizedEvent =
       Event(
@@ -100,8 +100,8 @@ class EventUIViewModelTest {
   fun setUp() {
     // Set up the test environment
     EnvironmentSetter.testLogin()
-      eventFirebaseConnection.add(event)
-        eventFirebaseConnection.add(event2)
+    eventFirebaseConnection.add(event)
+    eventFirebaseConnection.add(event2)
     // Unrate events
     ratingFirebaseConnection.update(
         event.id, testLoginUID, Rating.UNRATED, "T1qNNU05QeeqB2OqIBb7GAtQd093")
@@ -112,7 +112,6 @@ class EventUIViewModelTest {
     val profileTestOrganiser = Profile("testOrganiser", "bio", "image", testLoginUID, setOf())
     ProfileFirebaseConnection().add(profile1)
     ProfileFirebaseConnection().add(profileTestOrganiser)
-
   }
 
   @After
@@ -176,40 +175,40 @@ class EventUIViewModelTest {
     runBlocking {
       val viewModel = EventUIViewModel(event)
       delay(1000)
-      assertEquals(false, viewModel.canRate()) //not registered
+      assertEquals(false, viewModel.canRate()) // not registered
       viewModel.registerForEvent(event)
-        delay(400)
-        assertEquals(false, viewModel.canRate()) //registered but not attended
-        viewModel.attendEvent()
+      delay(400)
+      assertEquals(false, viewModel.canRate()) // registered but not attended
+      viewModel.attendEvent()
       delay(1000)
-        assertEquals(true, viewModel.attended.value)
-      assertEquals(true, viewModel.canRate()) //attended
-      val viewModel3 = EventUIViewModel(organizedEvent) //organizer
+      assertEquals(true, viewModel.attended.value)
+      assertEquals(true, viewModel.canRate()) // attended
+      val viewModel3 = EventUIViewModel(organizedEvent) // organizer
       delay(1000)
       assertEquals(false, viewModel3.canRate())
     }
   }
 
-    @Test
-    fun testCanAttend() {
-        runBlocking {
-            val viewModel = EventUIViewModel(event)
-            delay(1000)
-            assertEquals(false, viewModel.canAttend()) //isn't registered
-            viewModel.registerForEvent(event)
-            delay(1000)
-            assertEquals(true, viewModel.canAttend()) // registered and event is over
-            val viewModel2 = EventUIViewModel(event2)
-            delay(1000)
-            assertEquals(false, viewModel2.canAttend())
-            viewModel2.registerForEvent(event2)
-            delay(1000)
-            assertEquals(true, viewModel2.canAttend())
-            val viewModel3 = EventUIViewModel(organizedEvent)
-            delay(1000)
-            assertEquals(false, viewModel3.canAttend())
-        }
+  @Test
+  fun testCanAttend() {
+    runBlocking {
+      val viewModel = EventUIViewModel(event)
+      delay(1000)
+      assertEquals(false, viewModel.canAttend()) // isn't registered
+      viewModel.registerForEvent(event)
+      delay(1000)
+      assertEquals(true, viewModel.canAttend()) // registered and event is over
+      val viewModel2 = EventUIViewModel(event2)
+      delay(1000)
+      assertEquals(false, viewModel2.canAttend())
+      viewModel2.registerForEvent(event2)
+      delay(1000)
+      assertEquals(true, viewModel2.canAttend())
+      val viewModel3 = EventUIViewModel(organizedEvent)
+      delay(1000)
+      assertEquals(false, viewModel3.canAttend())
     }
+  }
 
   // Copy pasted from EventRegistrationViewModelTest.kt (cannot have viewModel as attribute because
   // it must be initialized in the test)
@@ -271,7 +270,7 @@ class EventUIViewModelTest {
             inscriptionLimitTime = null,
             image = "")
 
-  val viewModel = EventUIViewModel(event)
+    val viewModel = EventUIViewModel(event)
 
     val eventFirebaseConnection = EventFirebaseConnection()
     eventFirebaseConnection.add(event)
@@ -289,38 +288,38 @@ class EventUIViewModelTest {
     EnvironmentSetter.testLoginCleanUp()
   }
 
-@Test
-fun testAttendAsOrganizer() {
+  @Test
+  fun testAttendAsOrganizer() {
     runBlocking {
-        val viewModel = EventUIViewModel(organizedEvent)
-        delay(1000)
-        assertEquals(false, viewModel.attended.value)
-        viewModel.attendEvent()
-        delay(1000)
-        assertEquals(false, viewModel.attended.value)
+      val viewModel = EventUIViewModel(organizedEvent)
+      delay(1000)
+      assertEquals(false, viewModel.attended.value)
+      viewModel.attendEvent()
+      delay(1000)
+      assertEquals(false, viewModel.attended.value)
     }
-}
+  }
 
-    @Test
-    fun testAttendEvent() {
-        runBlocking {
-            EventFirebaseConnection().add(event)
-            val viewModel = EventUIViewModel(event)
-            delay(1000)
-            assertEquals(false, viewModel.attended.value)
-            viewModel.attendEvent() //not registered so attempt to attend should fail
-            delay(1000)
-            assertEquals(false, viewModel.attended.value)
+  @Test
+  fun testAttendEvent() {
+    runBlocking {
+      EventFirebaseConnection().add(event)
+      val viewModel = EventUIViewModel(event)
+      delay(1000)
+      assertEquals(false, viewModel.attended.value)
+      viewModel.attendEvent() // not registered so attempt to attend should fail
+      delay(1000)
+      assertEquals(false, viewModel.attended.value)
 
-            viewModel.registerForEvent(event)
-            delay(400)
-            viewModel.attendEvent()
-            delay(1000)
-            assertEquals(true, viewModel.attended.value) //is attending as far as the viewmodel is concerned
+      viewModel.registerForEvent(event)
+      delay(400)
+      viewModel.attendEvent()
+      delay(1000)
+      assertEquals(
+          true, viewModel.attended.value) // is attending as far as the viewmodel is concerned
 
-            val fetched = async {EventFirebaseConnection().fetch(event.id)}.await()
-            assertEquals(true, fetched?.finalAttendees?.contains(testLoginUID) == true )
-
-        }
+      val fetched = async { EventFirebaseConnection().fetch(event.id) }.await()
+      assertEquals(true, fetched?.finalAttendees?.contains(testLoginUID) == true)
     }
+  }
 }

--- a/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
@@ -314,7 +314,28 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
     return eventsFromQuerySnapshot(querySnapshot)
   }
 
-  /**
+    /**
+     * Fetch events the user has Attended.
+     *
+     * @return The list of events fetched
+     */
+    suspend fun fetchAttended(): MutableList<Event> {
+        Log.d(FirebaseAuth.getInstance().currentUser?.uid ?: "forTest", "fetchRegisteredTo: ")
+        val querySnapshot: QuerySnapshot =
+            Firebase.firestore
+                .collection(COLLECTION)
+                .orderBy("eventID")
+                .whereArrayContains(
+                    "finalAttendee", FirebaseAuth.getInstance().currentUser?.uid ?: "noneForTests")
+                .get()
+                .await()
+
+        return eventsFromQuerySnapshot(querySnapshot)
+    }
+
+
+
+    /**
    * Fetch events that are in the bounds of latitude and longitude +- degrees.
    *
    * @param latitude: The latitude to search around
@@ -379,6 +400,21 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
         .update("registeredUsers", FieldValue.arrayUnion(uid))
         .await()
   }
+
+
+    /**
+     * Add a user to the list of final attendee for an event.
+     *
+     * @param eventID: The id of the event
+     * @param uid: The id of the user
+     */
+    suspend fun addFinalAttendee(eventID: String, uid: String) {
+        Firebase.firestore
+            .collection(COLLECTION)
+            .document(eventID)
+            .update("finalAttendee", FieldValue.arrayUnion(uid))
+            .await()
+    }
 
   /**
    * Maps a string to a LocalTime object.

--- a/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
@@ -65,8 +65,8 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
       return null
     }
     val eventID = d.getString("eventID")!!
-    val title = d.getString("title")?: eventID
-    val description = d.getString("description")?: ""
+    val title = d.getString("title") ?: eventID
+    val description = d.getString("description") ?: ""
     val location: Location?
     val locationName = d.getString("locationName")!!
     location =
@@ -314,28 +314,26 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
     return eventsFromQuerySnapshot(querySnapshot)
   }
 
-    /**
-     * Fetch events the user has Attended.
-     *
-     * @return The list of events fetched
-     */
-    suspend fun fetchAttended(): MutableList<Event> {
-        Log.d(FirebaseAuth.getInstance().currentUser?.uid ?: "forTest", "fetchRegisteredTo: ")
-        val querySnapshot: QuerySnapshot =
-            Firebase.firestore
-                .collection(COLLECTION)
-                .orderBy("eventID")
-                .whereArrayContains(
-                    "finalAttendee", FirebaseAuth.getInstance().currentUser?.uid ?: "noneForTests")
-                .get()
-                .await()
+  /**
+   * Fetch events the user has Attended.
+   *
+   * @return The list of events fetched
+   */
+  suspend fun fetchAttended(): MutableList<Event> {
+    Log.d(FirebaseAuth.getInstance().currentUser?.uid ?: "forTest", "fetchRegisteredTo: ")
+    val querySnapshot: QuerySnapshot =
+        Firebase.firestore
+            .collection(COLLECTION)
+            .orderBy("eventID")
+            .whereArrayContains(
+                "finalAttendee", FirebaseAuth.getInstance().currentUser?.uid ?: "noneForTests")
+            .get()
+            .await()
 
-        return eventsFromQuerySnapshot(querySnapshot)
-    }
+    return eventsFromQuerySnapshot(querySnapshot)
+  }
 
-
-
-    /**
+  /**
    * Fetch events that are in the bounds of latitude and longitude +- degrees.
    *
    * @param latitude: The latitude to search around
@@ -401,20 +399,19 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
         .await()
   }
 
-
-    /**
-     * Add a user to the list of final attendee for an event.
-     *
-     * @param eventID: The id of the event
-     * @param uid: The id of the user
-     */
-    suspend fun addFinalAttendee(eventID: String, uid: String) {
-        Firebase.firestore
-            .collection(COLLECTION)
-            .document(eventID)
-            .update("finalAttendee", FieldValue.arrayUnion(uid))
-            .await()
-    }
+  /**
+   * Add a user to the list of final attendee for an event.
+   *
+   * @param eventID: The id of the event
+   * @param uid: The id of the user
+   */
+  suspend fun addFinalAttendee(eventID: String, uid: String) {
+    Firebase.firestore
+        .collection(COLLECTION)
+        .document(eventID)
+        .update("finalAttendee", FieldValue.arrayUnion(uid))
+        .await()
+  }
 
   /**
    * Maps a string to a LocalTime object.

--- a/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
@@ -295,6 +295,7 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
     return eventsFromQuerySnapshot(querySnapshot)
   }
 
+    /*
   /**
    * Fetch events the user is registered to.
    *
@@ -314,13 +315,38 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
     return eventsFromQuerySnapshot(querySnapshot)
   }
 
+     */
+
+    /**
+     * Fetch events the user is registered to and that are not over yet.
+     *
+     * @return The list of events fetched
+     */
+    suspend fun fetchUpComing(): MutableList<Event> {
+        Log.d(FirebaseAuth.getInstance().currentUser?.uid ?: "forTest", "fetchUpComing: ")
+        val querySnapshot: QuerySnapshot =
+            Firebase.firestore
+                .collection(COLLECTION)
+                .orderBy("eventEndDate")
+                .whereGreaterThanOrEqualTo(
+                    "eventEndDate",
+                    LocalDate.now().format(DateTimeFormatter.ofPattern(DATE_FORMAT_STORED)))
+                .whereArrayContains(
+                    "registeredUsers", FirebaseAuth.getInstance().currentUser?.uid ?: "noneForTests")
+                .get()
+                .await()
+
+        return eventsFromQuerySnapshot(querySnapshot)
+    }
+
+
   /**
    * Fetch events the user has Attended.
    *
    * @return The list of events fetched
    */
   suspend fun fetchAttended(): MutableList<Event> {
-    Log.d(FirebaseAuth.getInstance().currentUser?.uid ?: "forTest", "fetchRegisteredTo: ")
+    Log.d(FirebaseAuth.getInstance().currentUser?.uid ?: "forTest", "fetchAttended: ")
     val querySnapshot: QuerySnapshot =
         Firebase.firestore
             .collection(COLLECTION)

--- a/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
+++ b/app/src/main/java/com/github/se/gatherspot/firebase/EventFirebaseConnection.kt
@@ -65,8 +65,8 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
       return null
     }
     val eventID = d.getString("eventID")!!
-    val title = d.getString("title")!!
-    val description = d.getString("description")!!
+    val title = d.getString("title")?: eventID
+    val description = d.getString("description")?: ""
     val location: Location?
     val locationName = d.getString("locationName")!!
     location =
@@ -109,7 +109,7 @@ class EventFirebaseConnection : FirebaseConnectionInterface<Event> {
     val categoriesList = d.get("categories") as List<String>
     val categories = categoriesList.map { Interests.valueOf(it) }.toSet()
     val registeredUsers = d.get("registeredUsers") as MutableList<String>
-    val finalAttendee = d.get("finalAttendee") as MutableList<String>
+    val finalAttendee = d.get("finalAttendee") as MutableList<String> ?: mutableListOf()
     val image = d.getString("image")
     val globalRating =
         when (val rating = d.getString("globalRating")!!) {

--- a/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
@@ -570,10 +570,10 @@ class EventUtils {
         (event.eventEndDate == now && event.timeEnding?.isBefore(timeNow) == true)
   }
 
-    fun isEventStarted(event: Event): Boolean {
-        val now = LocalDate.now()
-        val timeNow = LocalTime.now()
-        return event.eventStartDate?.isBefore(now) == true ||
-                (event.eventStartDate == now && event.timeBeginning?.isBefore(timeNow) == true)
-    }
+  fun isEventStarted(event: Event): Boolean {
+    val now = LocalDate.now()
+    val timeNow = LocalTime.now()
+    return event.eventStartDate?.isBefore(now) == true ||
+        (event.eventStartDate == now && event.timeBeginning?.isBefore(timeNow) == true)
+  }
 }

--- a/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
@@ -569,4 +569,11 @@ class EventUtils {
     return event.eventEndDate?.isBefore(now) == true ||
         (event.eventEndDate == now && event.timeEnding?.isBefore(timeNow) == true)
   }
+
+    fun isEventStarted(event: Event): Boolean {
+        val now = LocalDate.now()
+        val timeNow = LocalTime.now()
+        return event.eventStartDate?.isBefore(now) == true ||
+                (event.eventStartDate == now && event.timeBeginning?.isBefore(timeNow) == true)
+    }
 }

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventRegistrationViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventRegistrationViewModel.kt
@@ -86,7 +86,7 @@ open class EventRegistrationViewModel(registered: List<String>) : ViewModel() {
       }
       if (!(event.registeredUsers.contains(userId))) {
         event.registeredUsers.add(userId)
-        eventDao?.insert(event)
+        //eventDao?.insert(event)
         eventFirebaseConnection.addRegisteredUser(event.id, userId)
         registeredEventsList.add(event.id)
         _registrationState.value = RegistrationState.Success
@@ -106,7 +106,7 @@ open class EventRegistrationViewModel(registered: List<String>) : ViewModel() {
   }
 
   // Self-explanatory
-  fun dismissAlert() {
+  open fun dismissAlert() {
     _displayAlertRegistration.value = false
     _displayAlertDeletion.value = false
   }

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventRegistrationViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventRegistrationViewModel.kt
@@ -86,7 +86,7 @@ open class EventRegistrationViewModel(registered: List<String>) : ViewModel() {
       }
       if (!(event.registeredUsers.contains(userId))) {
         event.registeredUsers.add(userId)
-        //eventDao?.insert(event)
+        // eventDao?.insert(event)
         eventFirebaseConnection.addRegisteredUser(event.id, userId)
         registeredEventsList.add(event.id)
         _registrationState.value = RegistrationState.Success

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
@@ -112,7 +112,7 @@ class EventUIViewModel(private val event: Event) :
    */
   fun canRate(): Boolean {
     return !isOrganizer() &&
-        event.registeredUsers.contains(userID) &&
+            (attended.value == true) &&
         EventUtils().isEventOver(event)
   }
 
@@ -147,7 +147,7 @@ class EventUIViewModel(private val event: Event) :
         return@launch
       }
       _attended.value = true
-      //event.finalAttendees.add(userID)
+      event.finalAttendees?.plus(userID)
       EventFirebaseConnection().addFinalAttendee(event.id, userID)
       _displayAlertAttend.value = true
 

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
+import com.github.se.gatherspot.firebase.EventFirebaseConnection
 import com.github.se.gatherspot.firebase.ProfileFirebaseConnection
 import com.github.se.gatherspot.firebase.RatingFirebaseConnection
 import com.github.se.gatherspot.model.EventUtils
@@ -34,6 +35,7 @@ class EventUIViewModel(private val event: Event) :
   private var _eventRating = MutableLiveData<Double>()
   private val userID = Firebase.auth.currentUser?.uid ?: "TEST"
   private val ratingFirebaseConnection = RatingFirebaseConnection()
+  private var _attended = MutableLiveData<Boolean>()
 
   init {
     viewModelScope.launch {
@@ -48,6 +50,7 @@ class EventUIViewModel(private val event: Event) :
           ratingFirebaseConnection.fetchOrganizerGlobalRating(event.organizerID) ?: 0.0
       _eventRating.value = ratingFirebaseConnection.fetchEventGlobalRating(event.id) ?: 0.0
       _organizer.value = ProfileFirebaseConnection().fetch(event.organizerID)
+      _attended.value = event.finalAttendees?.contains(userID) ?: false
 
       delay(500)
     }
@@ -57,6 +60,7 @@ class EventUIViewModel(private val event: Event) :
   val organizerRating: LiveData<Double> = _organizerRating
   val eventRating: LiveData<Double> = _eventRating
   val organizer: LiveData<Profile> = _organizer
+  val attended: LiveData<Boolean> = _attended
 
   /**
    * Rate the event
@@ -108,5 +112,28 @@ class EventUIViewModel(private val event: Event) :
     return !isOrganizer() &&
         event.registeredUsers.contains(userID) &&
         EventUtils().isEventOver(event)
+  }
+
+
+  fun attendEvent() {
+    viewModelScope.launch {
+      if (event.organizerID == userID) {
+        Log.e("AttendEvent", "Organizer cannot attend its own event")
+        return@launch
+      }
+      if (event.finalAttendees?.contains(userID) == true) {
+        Log.e("AttendEvent", "User $userID is already attending the event ${event.id}")
+        return@launch
+      }
+      if (!event.registeredUsers.contains(userID)) {
+        Log.e("AttendEvent", "User $userID is not registered for the event ${event.id}")
+        return@launch
+      }
+      _attended.value = true
+      //event.finalAttendees.add(userID)
+        EventFirebaseConnection().addFinalAttendee(event.id, userID)
+
+
+    }
   }
 }

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.launch
 class EventUIViewModel(private val event: Event) :
     EventRegistrationViewModel(event.registeredUsers) {
 
-
   private val _organizer = MutableLiveData<Profile>()
   private val _displayAlertAttend = MutableLiveData(false)
   private val _ownRating = MutableLiveData(Rating.UNRATED)
@@ -111,11 +110,8 @@ class EventUIViewModel(private val event: Event) :
    * @return true if the user can rate the event, false otherwise
    */
   fun canRate(): Boolean {
-    return !isOrganizer() &&
-            (attended.value == true) &&
-        EventUtils().isEventOver(event)
+    return !isOrganizer() && (attended.value == true) && EventUtils().isEventOver(event)
   }
-
 
   /**
    * Check if the user can attend the event
@@ -125,13 +121,10 @@ class EventUIViewModel(private val event: Event) :
   fun canAttend(): Boolean {
     return !isOrganizer() &&
         event.registeredUsers.contains(userID) &&
-            EventUtils().isEventStarted(event)
+        EventUtils().isEventStarted(event)
   }
 
-
-  /**
-   * Attend the event
-   */
+  /** Attend the event */
   fun attendEvent() {
     viewModelScope.launch {
       if (event.organizerID == userID) {
@@ -150,9 +143,6 @@ class EventUIViewModel(private val event: Event) :
       event.finalAttendees?.plus(userID)
       EventFirebaseConnection().addFinalAttendee(event.id, userID)
       _displayAlertAttend.value = true
-
-
-
     }
   }
 

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
@@ -28,14 +28,16 @@ import kotlinx.coroutines.launch
 class EventUIViewModel(private val event: Event) :
     EventRegistrationViewModel(event.registeredUsers) {
 
-  private var _organizer = MutableLiveData<Profile>()
+
+  private val _organizer = MutableLiveData<Profile>()
+  private val _displayAlertAttend = MutableLiveData(false)
   private lateinit var _attendees: List<String>
-  private var _ownRating = MutableLiveData(Rating.UNRATED)
-  private var _organizerRating = MutableLiveData<Double>()
-  private var _eventRating = MutableLiveData<Double>()
+  private val _ownRating = MutableLiveData(Rating.UNRATED)
+  private val _organizerRating = MutableLiveData<Double>()
+  private val _eventRating = MutableLiveData<Double>()
   private val userID = Firebase.auth.currentUser?.uid ?: "TEST"
   private val ratingFirebaseConnection = RatingFirebaseConnection()
-  private var _attended = MutableLiveData<Boolean>()
+  private val _attended = MutableLiveData<Boolean>()
 
   init {
     viewModelScope.launch {
@@ -61,6 +63,7 @@ class EventUIViewModel(private val event: Event) :
   val eventRating: LiveData<Double> = _eventRating
   val organizer: LiveData<Profile> = _organizer
   val attended: LiveData<Boolean> = _attended
+  val displayAlertAttend: LiveData<Boolean> = _displayAlertAttend
 
   /**
    * Rate the event
@@ -122,8 +125,8 @@ class EventUIViewModel(private val event: Event) :
    */
   fun canAttend(): Boolean {
     return !isOrganizer() &&
-        event.registeredUsers.contains(userID) &&
-        !event.finalAttendees?.contains(userID)!!
+        event.registeredUsers.contains(userID)
+    //TODO add isEventStarted
   }
 
 
@@ -146,9 +149,16 @@ class EventUIViewModel(private val event: Event) :
       }
       _attended.value = true
       //event.finalAttendees.add(userID)
-        EventFirebaseConnection().addFinalAttendee(event.id, userID)
+      EventFirebaseConnection().addFinalAttendee(event.id, userID)
+      _displayAlertAttend.value = true
+
 
 
     }
+  }
+
+  override fun dismissAlert() {
+    super.dismissAlert()
+    _displayAlertAttend.value = false
   }
 }

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
@@ -115,6 +115,21 @@ class EventUIViewModel(private val event: Event) :
   }
 
 
+  /**
+   * Check if the user can attend the event
+   *
+   * @return true if the user can attend the event, false otherwise
+   */
+  fun canAttend(): Boolean {
+    return !isOrganizer() &&
+        event.registeredUsers.contains(userID) &&
+        !event.finalAttendees?.contains(userID)!!
+  }
+
+
+  /**
+   * Attend the event
+   */
   fun attendEvent() {
     viewModelScope.launch {
       if (event.organizerID == userID) {

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventUIViewModel.kt
@@ -31,7 +31,6 @@ class EventUIViewModel(private val event: Event) :
 
   private val _organizer = MutableLiveData<Profile>()
   private val _displayAlertAttend = MutableLiveData(false)
-  private lateinit var _attendees: List<String>
   private val _ownRating = MutableLiveData(Rating.UNRATED)
   private val _organizerRating = MutableLiveData<Double>()
   private val _eventRating = MutableLiveData<Double>()
@@ -125,8 +124,8 @@ class EventUIViewModel(private val event: Event) :
    */
   fun canAttend(): Boolean {
     return !isOrganizer() &&
-        event.registeredUsers.contains(userID)
-    //TODO add isEventStarted
+        event.registeredUsers.contains(userID) &&
+            EventUtils().isEventStarted(event)
   }
 
 

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventView.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventView.kt
@@ -148,25 +148,23 @@ fun EventUINonOrganizer(
             actions = { ExportToCalendarIcon(event) })
       },
       bottomBar = {
-        RegisterButton(
-            event,
-            eventUIViewModel,
-            eventsViewModel,
-            isButtonEnabled,
-            buttonText,
-            showDialogRegistration,
-            registrationState,
-            eventDao)
-          RegisterButton(
-              event,
-              eventUIViewModel,
-              eventsViewModel,
-              isButtonEnabled,
-              buttonText,
-              showDialogRegistration,
-              registrationState,
-              eventDao)
-
+          Column {
+              if (eventUIViewModel.canAttend())
+              AttendButton(
+                  event,
+                  eventUIViewModel,
+              )
+              RegisterButton(
+                  event,
+                  eventUIViewModel,
+                  eventsViewModel,
+                  isButtonEnabled,
+                  buttonText,
+                  showDialogRegistration,
+                  registrationState,
+                  eventDao
+              )
+          }
 
       }) { innerPadding ->
         Column(
@@ -192,6 +190,54 @@ fun EventUINonOrganizer(
             }
       }
 }
+
+@Composable
+fun AttendButton(event: Event, eventUIViewModel: EventUIViewModel) {
+    val showDialogAttend by eventUIViewModel.displayAlertAttend.observeAsState()
+    val attended by eventUIViewModel.attended.observeAsState()
+    val buttonText = if (attended==true) "Attended" else "Attend"
+        /*
+        when (registrationState) {
+            is RegistrationState.Success -> "Registered"
+            is RegistrationState.Error ->
+                if ((registrationState as RegistrationState.Error).message == "Event is full") "Full"
+                else "Registered"
+            else -> "Register"
+        }
+
+         */
+
+    Button(
+        onClick = {
+            eventUIViewModel.attendEvent()
+        },
+        enabled = (attended==false),
+        modifier = Modifier.fillMaxWidth().testTag("attendButton"),
+        colors = ButtonDefaults.buttonColors(Color(0xFF3A89C9))) {
+        Text(buttonText, color = Color.White)
+    }
+
+    if (showDialogAttend!!) {
+        AlertDialog(
+            modifier = Modifier.testTag("alertBox"),
+            onDismissRequest = { eventUIViewModel.dismissAlert() },
+            title = { Text("Attending Result") },
+            text = {
+                Text("Attended")
+
+
+            },
+            confirmButton = {
+                Button(
+                    modifier = Modifier.testTag("okButton"),
+                    onClick = { eventUIViewModel.dismissAlert() }) {
+                    Text("OK")
+                }
+            })
+    }
+}
+
+
 
 /**
  * EventUIOrganizer displays the UI for an event for the organizer. It displays the title,

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventView.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventView.kt
@@ -157,6 +157,17 @@ fun EventUINonOrganizer(
             showDialogRegistration,
             registrationState,
             eventDao)
+          RegisterButton(
+              event,
+              eventUIViewModel,
+              eventsViewModel,
+              isButtonEnabled,
+              buttonText,
+              showDialogRegistration,
+              registrationState,
+              eventDao)
+
+
       }) { innerPadding ->
         Column(
             modifier =

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventView.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventView.kt
@@ -148,24 +148,22 @@ fun EventUINonOrganizer(
             actions = { ExportToCalendarIcon(event) })
       },
       bottomBar = {
-          Column {
-              if (eventUIViewModel.canAttend())
+        Column {
+          if (eventUIViewModel.canAttend())
               AttendButton(
                   event,
                   eventUIViewModel,
               )
-              RegisterButton(
-                  event,
-                  eventUIViewModel,
-                  eventsViewModel,
-                  isButtonEnabled,
-                  buttonText,
-                  showDialogRegistration,
-                  registrationState,
-                  eventDao
-              )
-          }
-
+          RegisterButton(
+              event,
+              eventUIViewModel,
+              eventsViewModel,
+              isButtonEnabled,
+              buttonText,
+              showDialogRegistration,
+              registrationState,
+              eventDao)
+        }
       }) { innerPadding ->
         Column(
             modifier =
@@ -193,51 +191,43 @@ fun EventUINonOrganizer(
 
 @Composable
 fun AttendButton(event: Event, eventUIViewModel: EventUIViewModel) {
-    val showDialogAttend by eventUIViewModel.displayAlertAttend.observeAsState()
-    val attended by eventUIViewModel.attended.observeAsState()
-    val buttonText = if (attended==true) "Attended" else "Attend"
-        /*
-        when (registrationState) {
-            is RegistrationState.Success -> "Registered"
-            is RegistrationState.Error ->
-                if ((registrationState as RegistrationState.Error).message == "Event is full") "Full"
-                else "Registered"
-            else -> "Register"
-        }
+  val showDialogAttend by eventUIViewModel.displayAlertAttend.observeAsState()
+  val attended by eventUIViewModel.attended.observeAsState()
+  val buttonText = if (attended == true) "Attended" else "Attend"
+  /*
+  when (registrationState) {
+      is RegistrationState.Success -> "Registered"
+      is RegistrationState.Error ->
+          if ((registrationState as RegistrationState.Error).message == "Event is full") "Full"
+          else "Registered"
+      else -> "Register"
+  }
 
-         */
+   */
 
-    Button(
-        onClick = {
-            eventUIViewModel.attendEvent()
-        },
-        enabled = (attended==false),
-        modifier = Modifier.fillMaxWidth().testTag("attendButton"),
-        colors = ButtonDefaults.buttonColors(Color(0xFF3A89C9))) {
+  Button(
+      onClick = { eventUIViewModel.attendEvent() },
+      enabled = (attended == false),
+      modifier = Modifier.fillMaxWidth().testTag("attendButton"),
+      colors = ButtonDefaults.buttonColors(Color(0xFF3A89C9))) {
         Text(buttonText, color = Color.White)
-    }
+      }
 
-    if (showDialogAttend!!) {
-        AlertDialog(
-            modifier = Modifier.testTag("alertBox"),
-            onDismissRequest = { eventUIViewModel.dismissAlert() },
-            title = { Text("Attending Result") },
-            text = {
-                Text("Attended")
-
-
-            },
-            confirmButton = {
-                Button(
-                    modifier = Modifier.testTag("okButton"),
-                    onClick = { eventUIViewModel.dismissAlert() }) {
-                    Text("OK")
-                }
-            })
-    }
+  if (showDialogAttend!!) {
+    AlertDialog(
+        modifier = Modifier.testTag("alertBox"),
+        onDismissRequest = { eventUIViewModel.dismissAlert() },
+        title = { Text("Attending Result") },
+        text = { Text("Attended") },
+        confirmButton = {
+          Button(
+              modifier = Modifier.testTag("okButton"),
+              onClick = { eventUIViewModel.dismissAlert() }) {
+                Text("OK")
+              }
+        })
+  }
 }
-
-
 
 /**
  * EventUIOrganizer displays the UI for an event for the organizer. It displays the title,

--- a/app/src/main/java/com/github/se/gatherspot/ui/topLevelDestinations/Events.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/topLevelDestinations/Events.kt
@@ -91,7 +91,8 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
   LaunchedEffect(init) {
     if (!init) {
       viewModel.fetchMyEvents()
-      viewModel.fetchRegisteredTo()
+      viewModel.fetchUpComing()
+      viewModel.fetchAttended()
       viewModel.fetchEventsFromFollowedUsers()
       init = true
     }
@@ -151,14 +152,24 @@ fun Events(viewModel: EventsViewModel, nav: NavigationActions) {
                             modifier = Modifier.testTag("myEvents"))
 
                         DropdownMenuItem(
-                            text = { Text("REGISTERED TO") },
+                            text = { Text("UPCOMING") },
                             onClick = {
                               MainActivity.selectedInterests = mutableListOf()
-                              viewModel.displayRegisteredTo()
+                              viewModel.displayUpComing()
                               showDropdownMenu = false
                             },
-                            leadingIcon = { Icon(Icons.Filled.Info, "registeredTo") },
-                            modifier = Modifier.testTag("registeredTo"))
+                            leadingIcon = { Icon(Icons.Filled.Info, "upComing") },
+                            modifier = Modifier.testTag("upComing"))
+
+                        DropdownMenuItem(
+                            text = { Text("ATTENDED") },
+                            onClick = {
+                              MainActivity.selectedInterests = mutableListOf()
+                              viewModel.displayAttended()
+                              showDropdownMenu = false
+                            },
+                            leadingIcon = { Icon(Icons.Filled.Info, "attended") },
+                            modifier = Modifier.testTag("attended"))
 
                         DropdownMenuItem(
                             text = { Text("FROM FOLLOWED") },

--- a/app/src/main/java/com/github/se/gatherspot/ui/topLevelDestinations/EventsViewModel.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/topLevelDestinations/EventsViewModel.kt
@@ -22,7 +22,8 @@ class EventsViewModel : ViewModel() {
   val uiState: StateFlow<UIState> = _uiState
   private var loadedEvents: MutableList<Event> = mutableListOf()
   private var myEvents: MutableList<Event> = mutableListOf()
-  private var registeredTo: MutableList<Event> = mutableListOf()
+  private var upComing: MutableList<Event> = mutableListOf()
+  private var attended: MutableList<Event> = mutableListOf()
   private var fromFollowedUsers: MutableList<Event> = mutableListOf()
   private var loadedFilteredEvents: MutableList<Event> = mutableListOf()
   val eventFirebaseConnection = EventFirebaseConnection()
@@ -42,8 +43,13 @@ class EventsViewModel : ViewModel() {
   }
 
   /** Fetches the events that the user has registered to and update viewModel. */
-  suspend fun fetchRegisteredTo() {
-    registeredTo = eventFirebaseConnection.fetchRegisteredTo()
+  suspend fun fetchUpComing() {
+    upComing = eventFirebaseConnection.fetchUpComing()
+  }
+
+  /** Fetches the events that the user has attended and update viewModel. */
+  suspend fun fetchAttended() {
+    attended = eventFirebaseConnection.fetchAttended()
   }
 
   /** Fetches the events from the followed users and update viewModel. */
@@ -60,9 +66,14 @@ class EventsViewModel : ViewModel() {
     _uiState.value = UIState(myEvents)
   }
 
+  /** Display the events that the user has registered to and that aren't over */
+  fun displayUpComing() {
+    _uiState.value = UIState(upComing)
+  }
+
   /** Display the events that the user has registered to. */
-  fun displayRegisteredTo() {
-    _uiState.value = UIState(registeredTo)
+  fun displayAttended() {
+    _uiState.value = UIState(attended)
   }
 
   /** Display the events from the followed users. */


### PR DESCRIPTION
- Created button to attend an event as well as the additional logic missing for attending (EventFirebaseConnection  : addFinalAttendee, EventUtils : isStarted, EventUIViewModel and EventView)
- Added functionality to fetch and display attended events in Events screen
-  Changed the logic for allowing rating to be based on Attendance rather than Registration
- Changed the Registered to tab in Events into an upcoming tab that shows registered to events that aren't over (This is to provide a clearer path for satisfying the user flow about rating events as well as having something closer to the user flow about having information about ongoing/future events. There is a convenient way to access them at least. Registered To is an ever expanding list of events, so very bad for browsing upcoming events that are in theory not numerous )

For each of this changes updated the test classes to test for new functionality or be adapted to updated functionality

After these changes are approved I would update the figma accordingly