### PR TITLE
Remove all runblocking from code

### DIFF
--- a/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
+++ b/app/src/main/java/com/github/se/gatherspot/model/EventUtils.kt
@@ -26,8 +26,9 @@ import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.sin
 import kotlin.math.sqrt
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
@@ -99,7 +100,7 @@ class EventUtils {
     FirebaseMessaging.getInstance().subscribeToTopic("event_${eventID}")
 
     // Add the event to the database
-    runBlocking {
+    CoroutineScope(Dispatchers.IO).launch {
       try {
         eventFirebaseConnection.add(event)
         eventDao?.insert(event)
@@ -116,7 +117,7 @@ class EventUtils {
   fun deleteEvent(event: Event, eventDao: EventDao? = null) {
     // Remove the event from all the users who registered for it
     val idListFirebase = IdListFirebaseConnection()
-    runBlocking {
+    CoroutineScope(Dispatchers.IO).launch {
       event.registeredUsers.forEach { userID ->
         val registeredEvents =
             idListFirebase.fetchFromFirebase(userID, FirebaseCollection.REGISTERED_EVENTS)
@@ -324,7 +325,7 @@ class EventUtils {
             eventStatus = EventStatus.CREATED,
         )
     // Add the event to the database
-    runBlocking {
+    CoroutineScope(Dispatchers.IO).launch {
       try {
         eventFirebaseConnection.add(event)
         eventDao?.insert(event)

--- a/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventDataForm.kt
+++ b/app/src/main/java/com/github/se/gatherspot/ui/eventUI/EventDataForm.kt
@@ -77,10 +77,11 @@ import java.text.SimpleDateFormat
 import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 private val WIDTH = 300.dp
 private val WIDTH_2ELEM = 150.dp
@@ -193,7 +194,7 @@ fun EventDataForm(
   val placeHolder = R.drawable.default_event_image
   val updateImageUri: (String) -> Unit = { imageUri = it }
   val deleteImage: () -> Unit = {
-    runBlocking {
+    CoroutineScope(Dispatchers.IO).launch {
       // if we create event it should never be already in the database
       if (eventAction == EDIT) {
         event?.id?.let { FirebaseImages().removePicture("eventImage", it) }
@@ -203,7 +204,7 @@ fun EventDataForm(
   }
   val uploadImage: () -> Unit = {
     if (event != null) {
-      runBlocking {
+      CoroutineScope(Dispatchers.IO).launch {
         imageUri = FirebaseImages().pushPicture(imageUri.toUri(), "eventImage", event.id)
       }
     }


### PR DESCRIPTION
Fix the crash when deleting an event by replacing the runblocking by a CoroutineScope(Dispatchers.IO).launch 